### PR TITLE
don't require cookie file and include class name and section number in filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features
 Directions
 ----------
 
-Requires Python 2.x (where x >= 5) and a free Coursera account.
+Requires Python 2.x (where x >= 5) and a free Coursera account enrolled in the class of interest.
 
 1. Install any missing dependencies.
 
@@ -40,10 +40,10 @@ Requires Python 2.x (where x >= 5) and a free Coursera account.
   * [easy_install] (for the above)  
   Ubuntu: `sudo apt-get install python-setuptools`  
   
-2. Create a Coursera.org account.
+2. Create a Coursera.org account and enroll in a class.
 e.g. http://saas-class.org  
 
-3. Login with your web browser.
+3. Login to that class with your web browser.
 
 4. Locate or export your Netscape-style cookies file with a browser extension.  
     Chrome: [Cookie.txt Export]  

--- a/coursera-dl
+++ b/coursera-dl
@@ -27,7 +27,7 @@ def get_auth_url(className):
   return "http://class.coursera.org/%s/auth/auth_redirector?type=login&subtype=normal&email=&visiting=&minimal=true" % className
 
 def write_cookie_file(className, username, password):
-  fn = tempfile.mkstemp()[1]
+  (hn,fn) = tempfile.mkstemp()
   cj = cookielib.MozillaCookieJar(fn)
   opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj), urllib2.HTTPHandler())
 
@@ -39,6 +39,9 @@ def write_cookie_file(className, username, password):
   opener.open(req)
 
   cj.save()
+  opener.close()
+  os.close(hn)
+
   return fn
 
 def load_cookies_file(cookies_file):
@@ -66,7 +69,10 @@ def get_opener(cookies_file):
 def get_page(url, cookies_file):
   """Download an HTML page using the cookiejar."""
   opener = get_opener(cookies_file)
-  return opener.open(url).read()
+  #return opener.open(url).read()
+  ret = opener.open(url).read()
+  opener.close()
+  return ret
 
 def get_syllabus(class_name, cookies_file, local_page=False):
   """ Get the course listing webpage."""
@@ -200,6 +206,7 @@ def download_file_nowget(url, fn, cookies_file):
     bytesread += len(data)
     print "\r%d bytes read" % bytesread,
     sys.stdout.flush()
+  urlfile.close()
 
 def parseArgs():
   parser = argparse.ArgumentParser(description='Download Coursera.org lecture material and resources.')


### PR DESCRIPTION
- don't require a cookie file, accept username + password as parameters
- include class name and section number in filenames
