### PR TITLE
Prompt for password if not given in command line or .netrc

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -381,7 +381,7 @@ def parseArgs():
     print >> sys.stderr, "Cookies file not found: " + args.cookies_file
     sys.exit(1)
   if args.username and not args.password and not args.netrc:
-    args.password = getpass.getpass("Password for %s@coursera.org: " % args.username)
+    args.password = getpass.getpass("Coursera password for %s: " % args.username)
   if args.netrc:
     auths = netrc.netrc().authenticators('coursera-dl')
     args.username = auths[0]


### PR DESCRIPTION
Password on command line may be visible system-wide in process listing and may be written to user's shell history.

Better to allow password prompted from terminal rather than just exiting if not supplied. Uses python's built-in `getpass` module.
