### PR TITLE
Added configurable netrc path

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -338,7 +338,7 @@ def download_file_curl(curl_bin, url, fn, cookies_file):
   Downloads a file using curl.  Could possibly use python to stream files to
   disk, but curl is robust and gives nice visual feedback.
   """
-  cmd = [curl_bin, url, "-L", "-o", fn, "--cookie", cookies_file]
+  cmd = [curl_bin, url, "-k", "-L", "-o", fn, "--cookie", cookies_file]
   logging.debug("Executing curl: %s", cmd)
   subprocess.call(cmd)
 


### PR DESCRIPTION
Nice work!

Netrc was not working on windows as the default paths en env variables differ. 
I extended the --netrc with configurable path. If no path is given or -n, -c and -u are omitted
a default netrc path is tried ($HOME/.netrc on *nix* or
%USERPROFILE%\_netrc on windows).

The -n -c and -u options ar no longer required. If no option is given the default netrc path is tried by default. Order of preference is -c, -u, -n.
