### PR TITLE
Adding option to download sections in reversed order

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -261,7 +261,7 @@ def get_anchor_format(a):
     return (fmt.group(1) if fmt else None)
 
 
-def parse_syllabus(page, cookies_file):
+def parse_syllabus(page, cookies_file, reverse=False):
     """
     Parses a Coursera course listing/syllabus page.  Each section is a week
     of classes.
@@ -309,6 +309,9 @@ def parse_syllabus(page, cookies_file):
 
     logging.info('Found %d sections and %d lectures on this page',
                  len(sections), sum(len(s[1]) for s in sections))
+
+    if sections and reverse:
+        sections = sections[::-1]
 
     if not len(sections):
         logging.error('Probably bad cookies file (or wrong class name)')
@@ -606,6 +609,13 @@ def parseArgs():
                         action='append',
                         default=[],
                         help='additional classes to get')
+    parser.add_argument('-r',
+                        '--reverse',
+                        dest='reverse',
+                        action='store_true',
+                        default=False,
+                        help='download sections in reverse order')
+
     args = parser.parse_args()
 
     # turn list of strings into list
@@ -658,7 +668,7 @@ def download_class(args, class_name):
 
     # parse it
     sections = parse_syllabus(page, args.cookies_file
-                              or tmp_cookie_file)
+                              or tmp_cookie_file, args.reverse)
 
     # obtain the resources
     download_lectures(


### PR DESCRIPTION
This commit adds a '-r' or '--reverse' parameter to add course sections in reverse order.
This prevents re-downloading all courses and keeps the week and lectures indices matching for courses that list their lecture list most recent first.
