### PR TITLE
Added a check for HTTPErrors without a 'reason' attribute

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -746,7 +746,7 @@ def download_file_nowget(url, fn, cookies_file):
                          ' waiting.')
             
             if hasattr(e, 'reason'):
-				error_msg = e.reason + ' ' + str(e.code)
+            	error_msg = e.reason + ' ' + str(e.code)
             else:
             	error_msg = 'HTTP Error '+str(e.code)
             	


### PR DESCRIPTION
For example, HTTP Error 403 does not have a 'reason' attribute, in this case the script throws an error and exits
