### PR TITLE
Download course description

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -553,7 +553,7 @@ def download_about(session, class_name, path='', overwrite=False):
   """
   Download the 'about' metadata which is in JSON format and pretty-print it.
   """
-  about_fn = os.path.join(path, 'about.json')
+  about_fn = os.path.join(path, class_name, 'about.json')
   if os.path.exists(about_fn) and not overwrite:
     return
   # strip off course number on end e.g. ml-001 -> ml


### PR DESCRIPTION
Adds the capability of downloading the JSON metadata for the class and storing it in "about.json" in the root directory for the class.  Currently it's defaulted off, and is enabled by "--about".

Let me know if you guys have any feedback.  Thanks to Jonas for the URL.
