### PR TITLE
Fix a video download issue in China

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -349,6 +349,8 @@ def download_lectures(downloader,
 
             # write lecture resources
             for fmt, url, title in resources_to_get:
+                if url.startswith('http:///'):
+                    url = url.replace('/', '', 1)
                 if combined_section_lectures_nums:
                     lecfn = os.path.join(
                         sec,


### PR DESCRIPTION
Video URLs provided by Coursera in China all start with http:///v.coursera.126.net/, the extra '/' makes downloader fail to retrieve video files. Removing a single '/' from URL fixes the issue.
