### PR TITLE
Changed cookie path for POSIX systems to avoid insufficient permissions.

### DIFF
--- a/coursera/define.py
+++ b/coursera/define.py
@@ -14,5 +14,10 @@ AUTH_REDIRECT_URL = 'https://class.coursera.org/{class_name}' \
                     '/auth/auth_redirector?type=login&subtype=normal'
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-PATH_CACHE = os.path.join(ROOT, '_cache')
+
+if os.name == 'posix':
+    PATH_CACHE = os.path.join('/tmp', '_coursera_dl_cache')
+else:
+    PATH_CACHE = os.path.join(ROOT, '_cache')
+
 PATH_COOKIES = os.path.join(PATH_CACHE, 'cookies')


### PR DESCRIPTION
Hello.

I tried to put `coursera` in the directory `/opt` so that every user of the computer can use the script. But when I ran the script as non-root users, I got permission denied at `_cache`.

So I did a small hack on the variable `PATH_CACHE`. I have tested the code myself, and it worked in my case.
