### PR TITLE
move cache folder from ROOT/_cache to tempdir determined by tempfile mod...

### DIFF
--- a/coursera/define.py
+++ b/coursera/define.py
@@ -15,5 +15,5 @@ AUTH_REDIRECT_URL = 'https://class.coursera.org/{class_name}' \
                     '/auth/auth_redirector?type=login&subtype=normal'
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-PATH_CACHE = tempfile.gettempdir()
+PATH_CACHE = os.path.join( tempfile.gettempdir(), '_coursera_dl_cache' )
 PATH_COOKIES = os.path.join(PATH_CACHE, 'cookies')


### PR DESCRIPTION
Keeping the cache path in the root folder is ok as long as you run it from within the folder. But if you install it in your system (e.g. in Arch Linux: https://aur.archlinux.org/packages/coursera-dl-git/), it will try to create the cache file in a folder that is accessible to root only (/usr/lib/python3.3/site-packages/_cache). Changing it to tempfile module helps finding a temporary folder that should work for the user (/tmp on linux).

Signed-off-by: Dominik Richter dominik.richter@gmail.com
