### PR TITLE
Adding a basic Windows-equivalent batch script to start coursera-dl

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ I've downloaded many other good videos such as those from Khan Academy.
 ## Instructions
 
 `coursera-dl` requires Python 2 (2.6 or newer) or Python 3 (3.2 or newer)
-and a free Coursera account enrolled in the class of interest.  *Note:* You
-must already have (manually) agreed to the Honor of Code of the particular
-courses that you want to use with `coursera-dl`.
+and a free Coursera account enrolled in the class of interest. On Windows
+ensure that Python executable location is added to the PATH environment variable.
+*Note:* You must already have (manually) agreed to the Honor of Code of the
+particular courses that you want to use with `coursera-dl`.
 
 ### Install any missing dependencies.
 
@@ -112,7 +113,8 @@ a class. See https://www.coursera.org/courses for the list of classes.
 ### Running the script
 
 Run the script to download the materials by providing your Coursera account
-(e.g., email address), password (or a `~/.netrc` file), the class names
+credentials (e.g. email address and password or a `~/.netrc` file), the class names,
+as well as any additional parameters:
 
     General:                     coursera-dl -u <user> -p <pass> modelthinking-004
     Multiple classes:            coursera-dl -u <user> -p <pass> saas historyofrock1-001 algo-2012-002
@@ -122,6 +124,7 @@ Run the script to download the materials by providing your Coursera account
     Use a ~/.netrc file:         coursera-dl -n -- matrix-001
     Get the preview classes:     coursera-dl -n -b ni-001
     Specify download path:       coursera-dl -n --path=C:\Coursera\Classes\ comnetworks-002
+    Display help:                coursera-dl --help
     
     Maintain a list of classes in a dir:
       Initialize:              mkdir -p CURRENT/{class1,class2,..classN}

--- a/coursera-dl.bat
+++ b/coursera-dl.bat
@@ -1,2 +1,9 @@
 @echo off
+rem Start-up script for Windows systems, ensuring out-of-the-box command execution as for *nix examples.
+rem Make sure the containing folder is referenced in %PATH%
+
+rem Usage: see "Running the script" section of the README for sample commands.
+
+rem Run "coursera-dl" in the current folder as working directory (where "%~dp0" is the
+rem location of this .bat file) via Python, passing all user-specified arguments ("%*")
 python %~dp0\coursera-dl %*


### PR DESCRIPTION
Makes the equivalent commands work on Windows via this simple batch script, as long as the containing folder is in PATH. Let me know whether I can contribute readme changes.
Cheers!
