### PR TITLE
Add test_clean_filename_minimal_change case for marketing-001

### DIFF
--- a/coursera/test/test_utils.py
+++ b/coursera/test/test_utils.py
@@ -34,7 +34,9 @@ class UtilsTestCase(unittest.TestCase):
             'Lecture 2.7 - Evaluation and Operators (16:25)':
             'Lecture 2.7 - Evaluation and Operators (16-25)',
             'Week 3: Data and Abstraction':
-            'Week 3- Data and Abstraction'
+            'Week 3- Data and Abstraction',
+            '  (Week 1) BRANDING:  Marketing Strategy and Brand Positioning':
+            '  (Week 1) BRANDING-  Marketing Strategy and Brand Positioning'
         }
         for k, v in iteritems(strings):
             self.assertEquals(utils.clean_filename(k, minimal_change=True), v)


### PR DESCRIPTION
closes #210
It checks if the section title is cleaned correctly, then filtering works as expected.
