### PR TITLE
README: Update preferred pip installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ first last at geemail dotcom or [@jplehmann][12]
 [15]: https://github.com/html5lib/html5lib-python
 [16]: http://docs.python-requests.org/en/latest/
 [17]: http://www.pip-installer.org/en/latest/
-[18]: http://python-distribute.org/pip_distribute.png
+[18]: https://stackoverflow.com/a/17601159 
 [19]: https://pypi.python.org/pypi/six/
 
 


### PR DESCRIPTION
From [pip Documentation](https://media.readthedocs.org/pdf/pip/1.5.X/pip.pdf) (v1.5.1)

> Beginning with v1.5.1, pip does not require setuptools prior to running get-pip.py. Additionally, if setuptools (or distribute) is not already installed, get-pip.py will install setuptools for you.

The installation method seems to be a little outdated. Also, it might be annoying for some users to read and manually type from an image file. I found [this](http://stackoverflow.com/q/5585875) related discussion on SO and thought it would be appropriate to change the link to the [best answer](http://stackoverflow.com/a/17601159) in the discussion. I was going to link from the official pip website but unfortunately it didn't look clear enough.
