### PR TITLE
Fixes #265

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -299,11 +299,15 @@ def download_about(session, class_name, path='', overwrite=False):
     # NOTE: should we create a directory with metadata?
     logging.info('Downloading about page from: %s', about_url)
     about_json = get_page(session, about_url)
-    data = json.loads(about_json)
-
-    with open(about_fn, 'w') as about_file:
-        json_data = json.dumps(data, indent=4, separators=(',', ':'))
-        about_file.write(json_data)
+    data = json.loads(about_json)["elements"]
+    
+    for element in data:
+        if element["shortName"] == base_class_name:
+            with open(about_fn, 'w') as about_file:
+                json_data = json.dumps(element, indent=4,
+                    separators=(',', ':'))
+                about_file.write(json_data)
+            break
 
 
 def download_lectures(downloader,

--- a/coursera/define.py
+++ b/coursera/define.py
@@ -10,8 +10,13 @@ import tempfile
 
 AUTH_URL = 'https://accounts.coursera.org/api/v1/login'
 CLASS_URL = 'https://class.coursera.org/{class_name}'
-ABOUT_URL = 'https://www.coursera.org/maestro/api/topic/information?' \
-            'topic-id={class_name}'
+ABOUT_URL = 'https://api.coursera.org/api/catalog.v1/courses?' \
+            'fields=largeIcon,photo,previewLink,shortDescription,smallIcon,' \
+            'smallIconHover,universityLogo,universityLogoSt,video,videoId,' \
+            'aboutTheCourse,targetAudience,faq,courseSyllabus,courseFormat,' \
+            'suggestedReadings,instructor,estimatedClassWorkload,' \
+            'aboutTheInstructor,recommendedBackground&' \
+            'q=search&query={class_name}'
 AUTH_REDIRECT_URL = 'https://class.coursera.org/{class_name}' \
                     '/auth/auth_redirector?type=login&subtype=normal'
 


### PR DESCRIPTION
Fixes #265 by using [Search API](https://tech.coursera.org/app-platform/catalog/#search) as there is no option to fetch the course information by `shortName` in [Catalog API](https://tech.coursera.org/app-platform/catalog/). 
