### PR TITLE
rm partial file upon non-zero exit of ExternalDownloader

### DIFF
--- a/coursera/downloaders.py
+++ b/coursera/downloaders.py
@@ -49,6 +49,21 @@ class Downloader(object):
             except OSError:
                 pass
             raise e
+        except subprocess.CalledProcessError as e:
+            logging.info(
+                'External Downloader Error -- Removing partial file: %s', filename)
+            logging.debug(
+                'External Downloader Return Code -- %s', e.returncode)
+            logging.debug(
+                'External Downloader cmd -- %s', e.cmd)
+            try:
+                os.remove(filename)
+            except OSError:
+                pass
+            # raise e
+            # -- don't raise the issue because some downloaders issue
+            #    a non zero exit code even for a simple connection break
+            #    so let the poor downloader try the next lecture.
 
 
 class ExternalDownloader(Downloader):
@@ -105,7 +120,7 @@ class ExternalDownloader(Downloader):
         self._prepare_cookies(command, url)
         logging.debug('Executing %s: %s', self.bin, command)
         try:
-            subprocess.call(command)
+            subprocess.check_call(command)
         except OSError as e:
             msg = "{0}. Are you sure that '{1}' is the right bin?".format(
                 e, self.bin)


### PR DESCRIPTION
we have to make sure to remove the partial file upon a non-zero exit code from the downloader..

let's take wget as an example if the user has a Good connection when downloading the Coursera class details and
has a Bad Connection when donwloading the list of lectures, the wget which has a -O option will create a blank file and exits with a read timeout error or a could not resolve error without deleting the blank file.
But that is just a single case where i faced the problem.