### PR TITLE
Fix decode for case when stdin is not present 

### DIFF
--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -21,7 +21,9 @@ else:
 
 if six.PY2:
     def decode_input(x):
-        return x.decode(sys.stdin.encoding)
+        stdin_encoding = sys.stdin.encoding
+        if stdin_encoding is None: stdin_encoding = "UTF-8"
+        return x.decode(stdin_encoding)
 else:
     def decode_input(x):
         return x


### PR DESCRIPTION
In cases when the environment doesn't have stdin,  for example when running test suites under jenkins your decode function fails.

Here is a fix for it.
