### PR TITLE
Selectable resolution (fixes #389)

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -371,7 +371,7 @@ def parse_syllabus(session, page, reverse=False, intact_fnames=False,
 
 
 def parse_on_demand_syllabus(session, page, reverse=False, intact_fnames=False,
-                             subtitle_language='en'):
+                             subtitle_language='en', video_resolution=None):
     """
     Parse a Coursera on-demand course listing/syllabus page.
     """
@@ -396,7 +396,8 @@ def parse_on_demand_syllabus(session, page, reverse=False, intact_fnames=False,
                     lecture_video_id = lecture['content']['definition']['videoId']
                     video_content = get_on_demand_video_url(session,
                                                             lecture_video_id,
-                                                            subtitle_language)
+                                                            subtitle_language,
+                                                            video_resolution)
                     lecture_video_content = {}
                     for key, value in video_content.items():
                         lecture_video_content[key] = [(value, '')]
@@ -533,7 +534,8 @@ def download_lectures(downloader,
                       playlist=False,
                       intact_fnames=False,
                       ignored_formats=None,
-                      resume=False):
+                      resume=False,
+                      video_resolution='540p'):
     """
     Download lecture resources described by sections.
 
@@ -1003,7 +1005,8 @@ def download_class(args, class_name):
                                   args.playlist,
                                   args.intact_fnames,
                                   ignored_formats,
-                                  args.resume)
+                                  args.resume,
+                                  args.video_resolution)
 
     return completed
 
@@ -1029,7 +1032,8 @@ def download_on_demand_class(args, class_name):
     modules = parse_on_demand_syllabus(session, page,
                                        args.reverse,
                                        args.intact_fnames,
-                                       args.subtitle_language)
+                                       args.subtitle_language,
+                                       args.video_resolution)
 
     downloader = get_downloader(session, class_name, args)
 

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -88,7 +88,8 @@ assert V(six.__version__) >= V('1.5'), "Upgrade six!" + _SEE_URL
 assert V(bs4.__version__) >= V('4.1'), "Upgrade bs4!" + _SEE_URL
 
 
-def get_on_demand_video_url(session, video_id, subtitle_language='en'):
+def get_on_demand_video_url(session, video_id, subtitle_language='en',
+                            resolution='540p'):
     """
     Return the download URL of on-demand course video.
     """
@@ -105,6 +106,23 @@ def get_on_demand_video_url(session, video_id, subtitle_language='en'):
     sources = dom['sources']
     sources.sort(key=lambda src: src['resolution'])
     sources.reverse()
+
+    # Try to select resolution requested by the user.
+    filtered_sources = [source
+                        for source in sources
+                        if source['resolution'] == resolution]
+
+    if len(filtered_sources) == 0:
+        # We will just use the 'vanilla' version of sources here, instead of
+        # filtered_sources.
+        logging.warn('Requested resolution %s not availaboe for <%s>. '
+                     'Downloading highest resolution available instead.',
+                     resolution, video_id)
+    else:
+        logging.info('Proceeding with download of resolution %s of <%s>.',
+                     resolution, video_id)
+        sources = filtered_sources
+
     video_url = sources[0]['formatSources']['video/mp4']
     video_content['mp4'] = video_url
 

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -734,6 +734,14 @@ def parse_args(args=None):
                                 help='only download resources which match this regex'
                                 ' (default: disabled)')
 
+    group_material.add_argument('--video-resolution',
+                                dest='video_resolution',
+                                action='store',
+                                default='540p',
+                                help='video resolution to download (default: 540p); '
+                                'only valid for on-demand courses; '
+                                'only values allowed: 360p, 540p, 720p')
+
     # Selection of material to download
     group_external_dl = parser.add_argument_group('External downloaders')
 

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -114,7 +114,7 @@ def get_on_demand_video_url(session, video_id, subtitle_language='en'):
     if subtitles is not None:
         if subtitle_language != 'en' and subtitle_language not in subtitles:
             logging.warning("Subtitle unavailable in '%s' language for video "
-                            "with video id: [%s], moving back to 'en' "
+                            "with video id: [%s], falling back to 'en' "
                             "subtitle", subtitle_language, video_id)
             subtitle_language = 'en'
 

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -96,10 +96,12 @@ def get_on_demand_video_url(session, video_id, subtitle_language='en'):
     url = OPENCOURSE_VIDEO_URL.format(video_id=video_id)
     page = get_page(session, url)
 
+    logging.debug('Parsing JSON for video_id <%s>.', video_id)
     video_content = {}
     dom = json.loads(page)
 
     # videos
+    logging.info('Gathering video URLs for video_id <%s>.', video_id)
     sources = dom['sources']
     sources.sort(key=lambda src: src['resolution'])
     sources.reverse()
@@ -107,6 +109,7 @@ def get_on_demand_video_url(session, video_id, subtitle_language='en'):
     video_content['mp4'] = video_url
 
     # subtitles
+    logging.info('Gathering subtitle URLs for video_id <%s>.', video_id)
     subtitles = dom.get('subtitles')
     if subtitles is not None:
         if subtitle_language != 'en' and subtitle_language not in subtitles:


### PR DESCRIPTION
Dear people,

This is a prototype to select the video resolution of courses. It, unfortunately, only works for on-demand courses (since I don't believe that regular courses offer videos in resolutions other than 540p yet).

The code here sucks a lot, since the program started "growing organically" and we have some functions with more than 10 parameters, which is a real madness (and we are essentially, just mimicking  passing the command line arguments object to the functions, but in a very poor style: "unboxing" the parameters).

I also have a hunch that it is not entirely absurd the idea that coursera may "phase out" what we currently know as "regular" courses and focus only on on-demand courses. That is, I believe that we may see the on-demand courses (for specializations) be their principal product.

So far, every course they have offered could be taken gratis. I have a hunch that this may become the exception rather than the norm, at which point it will be very hard to continue maintaining the project, since I don't believe that I would enroll in a paid course (unless if I were given financial compensation) just to debug a problem that I don't see with the courses that I can access gratis.

Let's hope that my vision of doom turns out to be completely unfounded. OTOH, I [have][0] seen some [evidence][1] to reinforce my beliefs.

[0]: http://blog.coursera.org/post/128115772357/30-new-business-computer-science-and-data#comment-2232089784
[1]: https://twitter.com/rtdbrito/status/639187291001462784