### PR TITLE
Extract more supplementary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ venv2
 venv3
 .idea
 .python-version
+.ipynb_checkpoints
+.ropeproject

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -26,63 +26,77 @@ class CourseraOnDemand(object):
     old-style Coursera classes. This API is by no means complete.
     """
 
-    def __init__(self, session, course_json):
+    def __init__(self, session, course_id):
         """
         Initialize Coursera OnDemand API.
 
         @param session: Current session that holds cookies and so on.
         @type session: requests.Session
+
+        @param course_id: Course ID from course json.
+        @type course_id: str
         """
         self._session = session
-        self._course_json = course_json
+        self._course_id = course_id
 
-        self._course_id = self._course_json['id']
-
-    def extract_files_from_programming(self, element_id):
+    def extract_links_from_programming(self, element_id):
         """
-        Return a dictionary with supplement files (pdf, csv, zip, ipynb, html
-        and so on) extracted from graded programming assignment.
+        Return a dictionary with links to supplement files (pdf, csv, zip,
+        ipynb, html and so on) extracted from graded programming assignment.
 
         @param element_id: Element ID to extract files from.
         @type element_id: str
 
-        @return: @see CourseraOnDemand._extract_supplement_links
+        @return: @see CourseraOnDemand._extract_links_from_text
         """
         logging.info('Gathering supplement URLs for element_id <%s>.', element_id)
 
         # Instructions contain text which in turn contains asset tags
         # which describe supplementary files.
-        instructions = ''.join(self._extract_assignment_instructions(element_id))
-        if not instructions:
+        text = ''.join(self._extract_assignment_text(element_id))
+        if not text:
             return {}
 
-        # Extract asset tags from instructions text
-        asset_map = self._extract_assets(instructions)
-        ids = list(iterkeys(asset_map))
-        if not ids:
-            return {}
-
-        # asset tags contain asset names and ids. We need to make another
-        # HTTP request to get asset URL.
-        asset_urls = self._extract_asset_urls(ids)
-
-        supplement_links = {}
-
-        # Build supplement links, providing nice titles along the way
-        for asset in asset_urls:
-            title = asset_map[asset['id']]['name']
-            extension = asset_map[asset['id']]['extension']
-            if extension not in supplement_links:
-                supplement_links[extension] = []
-            supplement_links[extension].append((asset['url'], title))
-
+        supplement_links = self._extract_links_from_text(text)
         return supplement_links
 
-    def _extract_assets(self, text):
+    def extract_links_from_supplement(self, element_id):
         """
-        Extract assets from text into a convenient form.
+        Return a dictionary with supplement files (pdf, csv, zip, ipynb, html
+        and so on) extracted from supplement page.
 
-        @param text: Text to extract assets from.
+        @return: @see CourseraOnDemand._extract_links_from_text
+        """
+        logging.info('Gathering supplement URLs for element_id <%s>.', element_id)
+
+        url = OPENCOURSE_SUPPLEMENT_URL.format(
+            course_id=self._course_id, element_id=element_id)
+        page = get_page(self._session, url)
+
+        dom = json.loads(page)
+        supplement_content = {}
+
+        # Supplement content has structure as follows:
+        # 'linked' {
+        #   'openCourseAssets.v1' [ {
+        #       'definition' {
+        #           'value'
+
+        for asset in dom['linked']['openCourseAssets.v1']:
+            value = asset['definition']['value']
+            # Supplement lecture types are known to contain both <asset> tags
+            # and <a href> tags (depending on the course), so we extract
+            # both of them.
+            self._extend_supplement_links(
+                supplement_content, self._extract_links_from_text(value))
+
+        return supplement_content
+
+    def _extract_asset_tags(self, text):
+        """
+        Extract asset tags from text into a convenient form.
+
+        @param text: Text to extract asset tags from.
         @type text: str
 
         @return: Asset map.
@@ -90,17 +104,18 @@ class CourseraOnDemand(object):
             '<id>': {
                 'name': '<name>',
                 'extension': '<extension>'
-            }
+            },
+            ...
         }
         """
         soup = BeautifulSoup(text)
-        asset_map = {}
+        asset_tags_map = {}
 
         for asset in soup.find_all('asset'):
-            asset_map[asset['id']] = {'name': asset['name'],
-                                      'extension': asset['extension']}
+            asset_tags_map[asset['id']] = {'name': asset['name'],
+                                           'extension': asset['extension']}
 
-        return asset_map
+        return asset_tags_map
 
     def _extract_asset_urls(self, asset_ids):
         """
@@ -124,14 +139,14 @@ class CourseraOnDemand(object):
                  'url': element['url']}
                 for element in dom['elements']]
 
-    def _extract_assignment_instructions(self, element_id):
+    def _extract_assignment_text(self, element_id):
         """
-        Extract assignment instructions.
+        Extract assignment text (instructions).
 
         @param element_id: Element id to extract assignment instructions from.
         @type element_id: str
 
-        @return: List of assignment instructions.
+        @return: List of assignment text (instructions).
         @rtype: [str]
         """
         url = OPENCOURSE_PROGRAMMING_ASSIGNMENTS_URL.format(
@@ -143,48 +158,77 @@ class CourseraOnDemand(object):
                 ['assignmentInstructions']['definition']['value']
                 for element in dom['elements']]
 
-    def extract_files_from_supplement(self, element_id):
+    def _extract_links_from_text(self, text):
         """
-        Return a dictionary with supplement files (pdf, csv, zip, ipynb, html
-        and so on) extracted from supplement page.
+        Extract supplement links from the html text. Links may be provided
+        in two ways:
+            1. <a> tags with href attribute
+            2. <asset> tags with id attribute (requires additional request
+               to get the direct URL to the asset file)
 
-        @return: @see CourseraOnDemand._extract_supplement_links
+        @param text: HTML text.
+        @type text: str
+
+        @return: Dictionary with supplement links grouped by extension.
+        @rtype: {
+            '<extension1>': [
+                ('<link1>', '<title1>'),
+                ('<link2>', '<title2')
+            ],
+            'extension2': [
+                ('<link3>', '<title3>'),
+                ('<link4>', '<title4>')
+            ],
+            ...
+        }
         """
-        logging.info('Gathering supplement URLs for element_id <%s>.', element_id)
+        supplement_links = self._extract_links_from_a_tags_in_text(text)
 
-        url = OPENCOURSE_SUPPLEMENT_URL.format(
-            course_id=self._course_id, element_id=element_id)
-        page = get_page(self._session, url)
+        self._extend_supplement_links(
+            supplement_links,
+            self._extract_links_from_asset_tags_in_text(text))
 
-        dom = json.loads(page)
-        supplement_content = {}
+        return supplement_links
 
-        # Supplement content has structure as follows:
-        # 'linked' {
-        #   'openCourseAssets.v1' [ {
-        #       'definition' {
-        #           'value'
-
-        for asset in dom['linked']['openCourseAssets.v1']:
-            value = asset['definition']['value']
-            more = self._extract_supplement_links(value)
-
-            for fmt, items in iteritems(more):
-                # We need to merge possible several supplement content results
-                if fmt in supplement_content:
-                    supplement_content[fmt].extend(more[fmt])
-                else:
-                    supplement_content[fmt] = more[fmt]
-
-        return supplement_content
-
-    def _extract_supplement_links(self, page):
+    def _extract_links_from_asset_tags_in_text(self, text):
         """
-        Extract supplement links from the html page that contains <a> tags
+        Scan the text and extract asset tags and links to corresponding
+        files.
+
+        @param text: Page text.
+        @type text: str
+
+        @return: @see CourseraOnDemand._extract_links_from_text
+        """
+        # Extract asset tags from instructions text
+        asset_tags_map = self._extract_asset_tags(text)
+        ids = list(iterkeys(asset_tags_map))
+        if not ids:
+            return {}
+
+        # asset tags contain asset names and ids. We need to make another
+        # HTTP request to get asset URL.
+        asset_urls = self._extract_asset_urls(ids)
+
+        supplement_links = {}
+
+        # Build supplement links, providing nice titles along the way
+        for asset in asset_urls:
+            title = asset_tags_map[asset['id']]['name']
+            extension = asset_tags_map[asset['id']]['extension']
+            if extension not in supplement_links:
+                supplement_links[extension] = []
+            supplement_links[extension].append((asset['url'], title))
+
+        return supplement_links
+
+    def _extract_links_from_a_tags_in_text(self, text):
+        """
+        Extract supplement links from the html text that contains <a> tags
         with href attribute.
 
-        @param page: HTML page.
-        @type page: str
+        @param text: HTML text.
+        @type text: str
 
         @return: Dictionary with supplement links grouped by extension.
         @rtype: {
@@ -198,7 +242,7 @@ class CourseraOnDemand(object):
             ]
         }
         """
-        soup = BeautifulSoup(page)
+        soup = BeautifulSoup(text)
         links = [item['href']
                  for item in soup.find_all('a') if 'href' in item.attrs]
         links = sorted(list(set(links)))
@@ -225,3 +269,20 @@ class CourseraOnDemand(object):
             supplement_links[extension].append((link, basename))
 
         return supplement_links
+
+    def _extend_supplement_links(self, destination, source):
+        """
+        Extends (merges) two dictionaries with supplement_links.
+
+        @param destination: Destination dictionary that will be extended.
+        @type destination: @see CourseraOnDemand._extract_links_from_text
+
+        @param source: Source dictionary that will be used to extend
+            destination dictionary.
+        @type source: @see CourseraOnDemand._extract_links_from_text
+        """
+        for key, value in iteritems(source):
+            if key not in destination:
+                destination[key] = value
+            else:
+                destination[key].extend(value)

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -16,6 +16,8 @@ from .network import get_page
 from .define import (OPENCOURSE_SUPPLEMENT_URL,
                      OPENCOURSE_PROGRAMMING_ASSIGNMENTS_URL,
                      OPENCOURSE_ASSET_URL,
+                     OPENCOURSE_ASSETS_URL,
+                     OPENCOURSE_API_ASSETS_V1_URL,
                      OPENCOURSE_VIDEO_URL)
 
 
@@ -44,10 +46,142 @@ class CourseraOnDemand(object):
                                    video_id, subtitle_language='en',
                                    resolution='540p', assets=None):
         """
-        Return the download URL of on-demand course video.
+        Return the download URLs of on-demand course video.
+
+        @param video_id: Video ID.
+        @type video_id: str
+
+        @param subtitle_language: Subtitle language.
+        @type subtitle_language: str
+
+        @param resolution: Preferred video resolution.
+        @type resolution: str
+
+        @param assets: List of assets that may present in the video.
+        @type assets: [str]
+
+        @return: @see CourseraOnDemand._extract_links_from_text
         """
         if assets is None:
             assets = []
+
+        links = self._extract_videos_and_subtitles_from_lecture(
+            video_id, subtitle_language, resolution)
+
+        assets = self._normalize_assets(assets)
+        self._extend_supplement_links(
+            links, self._extract_links_from_lecture_assets(assets))
+
+        return links
+
+    def _normalize_assets(self, assets):
+        """
+        Perform asset normalization. For some reason, assets that are sometimes
+        present in lectures, have "@1" at the end of their id. Such "uncut"
+        asset id when fed to OPENCOURSE_ASSETS_URL results in error that says:
+        "Routing error: 'get-all' not implemented". To avoid that, the last
+        two characters from asset id are cut off and after that that method
+        works fine. It looks like, Web UI is doing the same.
+
+        @param assets: List of asset ids.
+        @type assets: [str]
+
+        @return: Normalized list of asset ids (without trailing "@1")
+        @rtype: [str]
+        """
+        new_assets = []
+
+        for asset in assets:
+            # For example: giAxucdaEeWJTQ5WTi8YJQ@1
+            if len(asset) == 24:
+                # Turn it into: giAxucdaEeWJTQ5WTi8YJQ
+                asset = asset[:-2]
+            new_assets.append(asset)
+
+        return new_assets
+
+    def _extract_links_from_lecture_assets(self, asset_ids):
+        """
+        Extract links to files of the asset ids.
+
+        @param asset_ids: List of asset ids.
+        @type asset_ids: [str]
+
+        @return: @see CourseraOnDemand._extract_links_from_text
+        """
+        links = {}
+
+        def _add_asset(name, url, destination):
+            filename, extension = os.path.splitext(name)
+            if extension is '':
+                return
+
+            extension = extension.lower().strip('.')
+            basename = os.path.basename(filename)
+
+            if extension not in destination:
+                destination[extension] = []
+            destination[extension].append((url, basename))
+
+        for asset_id in asset_ids:
+            for open_course_asset_id in self._get_open_course_asset_ids(asset_id):
+                for asset in self._get_asset_urls(open_course_asset_id):
+                    _add_asset(asset['name'], asset['url'], links)
+
+        return links
+
+    def _get_open_course_asset_ids(self, asset_id):
+        """
+        Get asset ids (sub ids) that are children of the parent asset_id.
+
+        @param asset_id: Asset ID.
+        @type asset_id: str
+
+        @return: List of asset IDs.
+        @rtype: [str]
+        """
+        url = OPENCOURSE_ASSETS_URL.format(id=asset_id)
+        page = get_page(self._session, url)
+        logging.debug('Parsing JSON for asset_id <%s>.', asset_id)
+        dom = json.loads(page)
+
+        # Structure is as follows:
+        # elements [ {
+        #   definition {
+        #       assetId
+        return [element['definition']['assetId']
+                for element in dom['elements']]
+
+    def _get_asset_urls(self, asset_id):
+        """
+        Get list of asset urls and file names.
+
+        @param asset_id: Asset ID.
+        @type asset_id: str
+
+        @return List of dictionaries with asset file names and urls.
+        @rtype [{
+            'name': '<filename.ext>'
+            'url': '<url>'
+        }]
+        """
+        url = OPENCOURSE_API_ASSETS_V1_URL.format(id=asset_id)
+        page = get_page(self._session, url)
+        dom = json.loads(page)
+
+        # Structure is as follows:
+        # elements [ {
+        #   name
+        #   url {
+        #       url
+        return [{'name': element['name'],
+                 'url': element['url']['url']}
+                for element in dom['elements']]
+
+    def _extract_videos_and_subtitles_from_lecture(self,
+                                                   video_id,
+                                                   subtitle_language='en',
+                                                   resolution='540p'):
 
         url = OPENCOURSE_VIDEO_URL.format(video_id=video_id)
         page = get_page(self._session, url)
@@ -106,7 +240,7 @@ class CourseraOnDemand(object):
                         video_content[subtitle_language + '.' + subtitle_extension] = make_coursera_absolute_url(subtitle_url)
 
         lecture_video_content = {}
-        for key, value in video_content.items():
+        for key, value in iteritems(video_content):
             lecture_video_content[key] = [(value, '')]
 
         return lecture_video_content

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -66,11 +66,10 @@ from .cookies import (
     get_cookies_for_class, make_cookie_values, login, TLSAdapter)
 from .credentials import get_credentials, CredentialsError, keyring
 from .define import (CLASS_URL, ABOUT_URL, PATH_CACHE,
-                     OPENCOURSE_CONTENT_URL, OPENCOURSE_VIDEO_URL)
+                     OPENCOURSE_CONTENT_URL)
 from .downloaders import get_downloader
 from .utils import (clean_filename, get_anchor_format, mkdir_p, fix_url,
-                    decode_input, make_coursera_absolute_url,
-                    BeautifulSoup)
+                    decode_input, BeautifulSoup)
 from .network import get_page
 from .api import CourseraOnDemand
 
@@ -85,71 +84,6 @@ import six
 assert V(requests.__version__) >= V('2.4'), "Upgrade requests!" + _SEE_URL
 assert V(six.__version__) >= V('1.5'), "Upgrade six!" + _SEE_URL
 assert V(bs4.__version__) >= V('4.1'), "Upgrade bs4!" + _SEE_URL
-
-
-def get_on_demand_video_url(session, video_id, subtitle_language='en',
-                            resolution='540p'):
-    """
-    Return the download URL of on-demand course video.
-    """
-
-    url = OPENCOURSE_VIDEO_URL.format(video_id=video_id)
-    page = get_page(session, url)
-
-    logging.debug('Parsing JSON for video_id <%s>.', video_id)
-    video_content = {}
-    dom = json.loads(page)
-
-    # videos
-    logging.info('Gathering video URLs for video_id <%s>.', video_id)
-    sources = dom['sources']
-    sources.sort(key=lambda src: src['resolution'])
-    sources.reverse()
-
-    # Try to select resolution requested by the user.
-    filtered_sources = [source
-                        for source in sources
-                        if source['resolution'] == resolution]
-
-    if len(filtered_sources) == 0:
-        # We will just use the 'vanilla' version of sources here, instead of
-        # filtered_sources.
-        logging.warn('Requested resolution %s not available for <%s>. '
-                     'Downloading highest resolution available instead.',
-                     resolution, video_id)
-    else:
-        logging.info('Proceeding with download of resolution %s of <%s>.',
-                     resolution, video_id)
-        sources = filtered_sources
-
-    video_url = sources[0]['formatSources']['video/mp4']
-    video_content['mp4'] = video_url
-
-    # subtitles and transcripts
-    subtitle_nodes = [
-        ('subtitles',    'srt', 'subtitle'),
-        ('subtitlesTxt', 'txt', 'transcript'),
-    ]
-    for (subtitle_node, subtitle_extension, subtitle_description) in subtitle_nodes:
-        logging.info('Gathering %s URLs for video_id <%s>.', subtitle_description, video_id)
-        subtitles = dom.get(subtitle_node)
-        if subtitles is not None:
-            if subtitle_language == 'all':
-                for current_subtitle_language in subtitles:
-                    video_content[current_subtitle_language + '.' + subtitle_extension] = make_coursera_absolute_url(subtitles.get(current_subtitle_language))
-            else:
-                if subtitle_language != 'en' and subtitle_language not in subtitles:
-                    logging.warning("%s unavailable in '%s' language for video "
-                                    "with video id: [%s], falling back to 'en' "
-                                    "%s", subtitle_description.capitalize(), subtitle_language, video_id, subtitle_description)
-                subtitle_language = 'en'
-
-                subtitle_url = subtitles.get(subtitle_language)
-                if subtitle_url is not None:
-                    # some subtitle urls are relative!
-                    video_content[subtitle_language + '.' + subtitle_extension] = make_coursera_absolute_url(subtitle_url)
-
-    return video_content
 
 
 def get_syllabus_url(class_name, preview):
@@ -390,16 +324,15 @@ def parse_on_demand_syllabus(session, page, reverse=False, intact_fnames=False,
 
                 if typename == 'lecture':
                     lecture_video_id = lecture['content']['definition']['videoId']
-                    video_content = get_on_demand_video_url(session,
-                                                            lecture_video_id,
-                                                            subtitle_language,
-                                                            video_resolution)
-                    lecture_video_content = {}
-                    for key, value in video_content.items():
-                        lecture_video_content[key] = [(value, '')]
+                    assets = lecture['content']['definition'].get('assets', [])
 
-                    if lecture_video_content:
-                        lectures.append((lecture_slug, lecture_video_content))
+                    links = course.extract_links_from_lecture(
+                        lecture_video_id, subtitle_language,
+                        video_resolution, assets)
+
+                    if links:
+                        lectures.append((lecture_slug, links))
+
                 elif typename == 'supplement':
                     supplement_content = course.extract_links_from_supplement(
                         lecture['id'])

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -374,7 +374,7 @@ def parse_on_demand_syllabus(session, page, reverse=False, intact_fnames=False,
                  'This may take some time, be patient ...')
     modules = []
     json_modules = dom['courseMaterial']['elements']
-    course = CourseraOnDemand(session, dom)
+    course = CourseraOnDemand(session, dom['id'])
 
     for module in json_modules:
         module_slug = module['slug']
@@ -401,12 +401,13 @@ def parse_on_demand_syllabus(session, page, reverse=False, intact_fnames=False,
                     if lecture_video_content:
                         lectures.append((lecture_slug, lecture_video_content))
                 elif typename == 'supplement':
-                    supplement_content = course.extract_files_from_supplement(
+                    supplement_content = course.extract_links_from_supplement(
                         lecture['id'])
                     if supplement_content:
                         lectures.append((lecture_slug, supplement_content))
+
                 elif typename in ('gradedProgramming', 'ungradedProgramming'):
-                    supplement_content = course.extract_files_from_programming(
+                    supplement_content = course.extract_links_from_programming(
                         lecture['id'])
                     if supplement_content:
                         lectures.append((lecture_slug, supplement_content))

--- a/coursera/define.py
+++ b/coursera/define.py
@@ -18,8 +18,100 @@ OPENCOURSE_SUPPLEMENT_URL = 'https://www.coursera.org/api/onDemandSupplements.v1
     '{course_id}~{element_id}?includes=asset&fields=openCourseAssets.v1%28typeName%29,openCourseAssets.v1%28definition%29'
 OPENCOURSE_PROGRAMMING_ASSIGNMENTS_URL = \
     'https://www.coursera.org/api/onDemandProgrammingLearnerAssignments.v1/{course_id}~{element_id}?fields=submissionLearnerSchema'
+
+# These are ids that are present in <asset> tag in assignment text:
+#
+# <asset id=\"yeJ7Q8VAEeWPRQ4YsSEORQ\"
+#        name=\"statement-pca\"
+#        extension=\"pdf\"
+#        assetType=\"generic\"/>
+#
+# Sample response:
+#
+# {
+#   "elements": [
+#     {
+#       "id": "yeJ7Q8VAEeWPRQ4YsSEORQ",
+#       "url": "<some url>",
+#       "expires": 1454371200000
+#     }
+#   ],
+#   "paging": null,
+#   "linked": null
+# }
 OPENCOURSE_ASSET_URL = \
     'https://www.coursera.org/api/assetUrls.v1?ids={ids}'
+
+# These ids are provided in lecture json:
+#
+# {
+#   "id": "6ydIh",
+#   "name": "Введение в теорию игр",
+#   "elements": [
+#     {
+#       "id": "ujNfj",
+#       "name": "Что изучает теория игр?",
+#       "content": {
+#         "typeName": "lecture",
+#         "definition": {
+#           "duration": 536000,
+#           "videoId": "pGNiQYo-EeWNvA632PIn3w",
+#           "optional": false,
+#           "assets": [
+#             "giAxucdaEeWJTQ5WTi8YJQ@1"
+#           ]
+#         }
+#       },
+#       "slug": "chto-izuchaiet-tieoriia-ighr",
+#       "timeCommitment": 536000
+#     }
+#   ],
+#   "slug": "vviedieniie-v-tieoriiu-ighr",
+#   "timeCommitment": 536000,
+#   "optional": false
+# }
+#
+# Sample response:
+#
+# {
+#   "elements": [
+#     {
+#       "id": "giAxucdaEeWJTQ5WTi8YJQ",
+#       "typeName": "asset",
+#       "definition": {
+#         "name": "",
+#         "assetId": "Vq8hwsdaEeWGlA7xclFASw"
+#       }
+#     }
+#   ],
+#   "paging": null,
+#   "linked": null
+# }
+OPENCOURSE_ASSETS_URL = \
+    'https://www.coursera.org/api/openCourseAssets.v1/{id}'
+
+# These asset ids are ids returned from OPENCOURSE_ASSETS_URL request:
+# See example above.
+#
+# Sample response:
+#
+# {
+#   "elements": [
+#     {
+#       "id": "Vq8hwsdaEeWGlA7xclFASw",
+#       "name": "1_Strategic_Interactions.pdf",
+#       "typeName": "generic",
+#       "url": {
+#         "url": "<some url>",
+#         "expires": 1454371200000
+#       }
+#     }
+#   ],
+#   "paging": null,
+#   "linked": null
+# }
+OPENCOURSE_API_ASSETS_V1_URL = \
+    'https://www.coursera.org/api/assets.v1/{id}'
 
 
 ABOUT_URL = ('https://api.coursera.org/api/catalog.v1/courses?'

--- a/coursera/test/fixtures/json/supplement-api-assets-v1-reply.json
+++ b/coursera/test/fixtures/json/supplement-api-assets-v1-reply.json
@@ -1,0 +1,15 @@
+{
+  "elements": [
+    {
+      "id": "Vq8hwsdaEeWGlA7xclFASw",
+      "name": "1_Strategic_Interactions.pdf",
+      "typeName": "generic",
+      "url": {
+        "url": "https://d3c33hcgiwev3.cloudfront.net/_0d20d70b215dddf92600a02b7522bff1_1_Strategic_Interactions.pdf?Expires=1454371200&Signature=SvB7NQUy5nPMxVawp3qTe7DsOWGinH8WmITsi5Vp-fgR7l71Hkgup4s6Eo28hUngKta025frvxYLDoRRX1bOP9RQ2TkTTlBuI7TYzeP~7tI9TDVlFrUAf81BOmULyAcVryWKjy~aUSsYJp94aTrAvaJ7KBUZ6bhMQ~TTx9od~LI_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+        "expires": 1454371200000
+      }
+    }
+  ],
+  "paging": null,
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-extract-links-from-lectures-output.json
+++ b/coursera/test/fixtures/json/supplement-extract-links-from-lectures-output.json
@@ -1,0 +1,8 @@
+{
+  "pdf": [
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_0d20d70b215dddf92600a02b7522bff1_1_Strategic_Interactions.pdf?Expires=1454371200&Signature=SvB7NQUy5nPMxVawp3qTe7DsOWGinH8WmITsi5Vp-fgR7l71Hkgup4s6Eo28hUngKta025frvxYLDoRRX1bOP9RQ2TkTTlBuI7TYzeP~7tI9TDVlFrUAf81BOmULyAcVryWKjy~aUSsYJp94aTrAvaJ7KBUZ6bhMQ~TTx9od~LI_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "1_Strategic_Interactions"
+    ]
+  ]
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-reply.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-reply.json
@@ -1,0 +1,14 @@
+{
+  "elements": [
+    {
+      "id": "giAxucdaEeWJTQ5WTi8YJQ",
+      "typeName": "asset",
+      "definition": {
+        "name": "",
+        "assetId": "Vq8hwsdaEeWGlA7xclFASw"
+      }
+    }
+  ],
+  "paging": null,
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-three-assets-output.json
+++ b/coursera/test/fixtures/json/supplement-three-assets-output.json
@@ -1,0 +1,36 @@
+{
+  "csv": [
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_82b4a9f66c689b3d40dd25ebd761b07f_close_prices.csv?Expires=1454198400&Signature=bfgnJPMO7gugESqp6LRRdO-HP0X8~Y19GK9BGPjdU4bJQlR79iDLNgNMlAaCb3GhzyBAqv~46zr1XPY8VLY-QY2E0mnPVXlNLzgnS6Ypf2i~2J4jpI5UpGS4tuyT3mKxweaMttgTl3YvQFqSZX9an-TZRCDjgu57ucKfSAHkwRc_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "close_prices"
+    ],
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_82b4a9f66c689b3d40dd25ebd761b07f_djia_index.csv?Expires=1454198400&Signature=ev67ad4IofngeNCBOxHN1bQ3DVQ48puKT7cW0-yHR7FlcypM9~12mnBKOkmD8yaiZlXCR8Mf5CY1KckPSHZKnxOqtgRacy7Ez5qvG1w50QIH0~NDMMZMD2uXgcnssv1ISiuMAST51~Qdlu5HwY8TL6zYTn56QEQbT9xe80V4TVc_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "djia_index"
+    ]
+  ],
+  "html": [
+    [
+      "http://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.corrcoef.html",
+      "numpy.corrcoef"
+    ]
+  ],
+  "html\\": [
+    [
+      "http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html\\",
+      "sklearn.decomposition.PCA"
+    ]
+  ],
+  "pdf": [
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_3cdeda0745801a9686d7f5601010fb0c_statement-pca.pdf?Expires=1454198400&Signature=h5uo5XCq8DN-X6jf9VpJXj5-0M3LfBQmgf6LamlkrmH9YexVGjbVc3McRfvivJ9eQDXPo~ZujKw7YLc8BnCjDZA5hfwpF5q2J7dk4-ssK2ZA2-AIAukuURURZqFypiR7qbEFUHtDnWlSP16Q59X8D1g-PtVIEMUop4fgvGs3Px4_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "statement-pca"
+    ]
+  ],
+  "transform": [
+    [
+      "http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PCA.transform",
+      "sklearn.decomposition.PCA.html#sklearn.decomposition.PCA"
+    ]
+  ]
+}

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -58,3 +58,16 @@ def test_ondemand_programming_supplement_three_assets(get_page, course):
     output = course.extract_links_from_programming('0')
     output = json.loads(json.dumps(output))
     assert expected_output == output
+
+
+@patch('coursera.api.get_page')
+def test_extract_links_from_lecture_assets(get_page, course):
+    open_course_assets_reply = slurp_fixture('json/supplement-open-course-assets-reply.json')
+    api_assets_v1_reply = slurp_fixture('json/supplement-api-assets-v1-reply.json')
+    get_page.side_effect = [open_course_assets_reply, api_assets_v1_reply]
+
+    expected_output = json.loads(slurp_fixture('json/supplement-extract-links-from-lectures-output.json'))
+    assets = ['giAxucdaEeWJTQ5WTi8YJQ']
+    output = course._extract_links_from_lecture_assets(assets)
+    output = json.loads(json.dumps(output))
+    assert expected_output == output

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -1,7 +1,6 @@
 """
 Test APIs.
 """
-import os
 import json
 
 import pytest
@@ -9,16 +8,13 @@ from mock import patch
 
 from coursera import api
 
+from coursera.test.utils import slurp_fixture
+
 
 @pytest.fixture
 def course():
-    course = api.CourseraOnDemand(session=None, course_json={'id': 0})
+    course = api.CourseraOnDemand(session=None, course_id='0')
     return course
-
-
-def slurp_fixture(path):
-    return open(os.path.join(os.path.dirname(__file__),
-                             "fixtures", path)).read()
 
 
 @patch('coursera.api.get_page')
@@ -26,8 +22,8 @@ def test_ondemand_programming_supplement_no_instructions(get_page, course):
     no_instructions = slurp_fixture('json/supplement-programming-no-instructions.json')
     get_page.return_value = no_instructions
 
-    files = course.extract_files_from_programming('0')
-    assert {} == files
+    output = course.extract_links_from_programming('0')
+    assert {} == output
 
 
 @patch('coursera.api.get_page')
@@ -35,8 +31,8 @@ def test_ondemand_programming_supplement_empty_instructions(get_page, course):
     empty_instructions = slurp_fixture('json/supplement-programming-empty-instructions.json')
     get_page.return_value = empty_instructions
 
-    files = course.extract_files_from_programming('0')
-    assert {} == files
+    output = course.extract_links_from_programming('0')
+    assert {} == output
 
 
 @patch('coursera.api.get_page')
@@ -46,23 +42,19 @@ def test_ondemand_programming_supplement_one_asset(get_page, course):
     asset_json = json.loads(one_asset_url)
     get_page.side_effect = [one_asset_tag, one_asset_url]
 
-    expected_files = {'pdf': [(asset_json['elements'][0]['url'],
+    expected_output = {'pdf': [(asset_json['elements'][0]['url'],
                                'statement-pca')]}
-    files = course.extract_files_from_programming('0')
-    assert expected_files == files
+    output = course.extract_links_from_programming('0')
+    assert expected_output == output
 
 
 @patch('coursera.api.get_page')
 def test_ondemand_programming_supplement_three_assets(get_page, course):
     three_assets_tag = slurp_fixture('json/supplement-programming-three-assets.json')
     three_assets_url = slurp_fixture('json/asset-urls-three.json')
-    asset_json = json.loads(three_assets_url)
     get_page.side_effect = [three_assets_tag, three_assets_url]
 
-    expected_files = {
-        'csv': [(asset_json['elements'][0]['url'], 'close_prices'),
-                (asset_json['elements'][2]['url'], 'djia_index')],
-        'pdf': [(asset_json['elements'][1]['url'], 'statement-pca')]
-    }
-    files = course.extract_files_from_programming('0')
-    assert expected_files == files
+    expected_output = json.loads(slurp_fixture('json/supplement-three-assets-output.json'))
+    output = course.extract_links_from_programming('0')
+    output = json.loads(json.dumps(output))
+    assert expected_output == output

--- a/coursera/test/test_parsing.py
+++ b/coursera/test/test_parsing.py
@@ -126,8 +126,8 @@ def test_get_on_demand_supplement_url_accumulates_assets(mocked):
         os.path.join(os.path.dirname(__file__),
                      "fixtures", "json", "supplement-multiple-assets-output.json")))
     mocked.return_value = input
-    course = api.CourseraOnDemand(session=None, course_json={'id': 0})
-    output = course.extract_files_from_supplement('element_id')
+    course = api.CourseraOnDemand(session=None, course_id='0')
+    output = course.extract_links_from_supplement('element_id')
 
     # This is the easiest way to convert nested tuples to lists
     output = json.loads(json.dumps(output))

--- a/coursera/test/test_utils.py
+++ b/coursera/test/test_utils.py
@@ -18,6 +18,8 @@ from coursera import utils
 from coursera import coursera_dl
 from coursera import api
 
+from coursera.test.utils import slurp_fixture
+
 
 @pytest.mark.parametrize(
     "unclean,clean", [
@@ -226,13 +228,11 @@ def test_grab_hidden_video_url():
     ]
 )
 def test_extract_supplement_links(input, output):
-    input_filename = os.path.join(os.path.dirname(__file__), "fixtures", input)
-    output_filename = os.path.join(os.path.dirname(__file__), "fixtures", output)
-    page_text = open(input_filename).read()
-    expected_output = json.load(open(output_filename))
+    page_text = slurp_fixture(input)
+    expected_output = json.loads(slurp_fixture(output))
 
-    course = api.CourseraOnDemand(session=None, course_json={'id': 0})
-    output = course._extract_supplement_links(page_text)
+    course = api.CourseraOnDemand(session=None, course_id='0')
+    output = course._extract_links_from_text(page_text)
     # This is the easiest way to convert nested tuples to lists
     output = json.loads(json.dumps(output))
 

--- a/coursera/test/utils.py
+++ b/coursera/test/utils.py
@@ -1,0 +1,9 @@
+"""
+Helper functions that are only used in tests.
+"""
+import os
+
+
+def slurp_fixture(path):
+    return open(os.path.join(os.path.dirname(__file__),
+                             "fixtures", path)).read()


### PR DESCRIPTION
This pull request adds extraction of supplementary files (e.g. PDFs) from lecture units.

There are many ways on the new Coursera platform to provide supplementary files. Different course makers use different facilities for that. As a result, it gets complicated and intricate during the
parsing/extraction. Thank got we only have to work with json structure, not (almost never) HTML.

This pull request is the second attempt to fix #425.