### PR TITLE
coursera/api: Skip JSON documents with missing assetId.

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -149,8 +149,13 @@ class CourseraOnDemand(object):
         # elements [ {
         #   definition {
         #       assetId
+
+        # FIXME (rbrito): Study closer how are the JSON documents that can get us
+        # here.
+
         return [element['definition']['assetId']
-                for element in dom['elements']]
+                for element in dom['elements']
+                if element['definition'].get('assetId', None)]
 
     def _get_asset_urls(self, asset_id):
         """


### PR DESCRIPTION
Some JSON documents for some courses in Coursera's New Platform don't always
have an `assetId` attribute right below a `definition` attribute.

Since we convert a JSON document to a Python dictionary, we can't
(unfortunately) just go ahead and access something like
`element['definition']['assetId']`.

Important aside: It seems, during my tests with the `graph-analytics` course
that the method `_get_open_course_asset_ids` only gets called with such
"defective" JSON documents, which *may* indicate that the `if` filtering in
the list comprehension is always necessary and the lists returned by
`_get_open_course_asset_ids` are always empty after filtering (again, at
least with this course; haven't tested with others).

We should investigate things better and see what kind of JSON documents get
us there and, if possible, categorize the documents that Coursera spits so
that we have a better idea of what they are sending us and how to behave.

One (wild) idea would be to have a method for each possible type of JSON
document returning the data structures that we need.

Signed-off-by: Rogério Brito <rbrito@ime.usp.br>