### PR TITLE
Support asset elements of typename='url'

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf8 :
 """
 This module contains implementations of different APIs that are used by the
 downloader.

--- a/coursera/test/fixtures/json/supplement-extract-links-from-lectures-url-asset-output.json
+++ b/coursera/test/fixtures/json/supplement-extract-links-from-lectures-url-asset-output.json
@@ -1,0 +1,18 @@
+{
+  "pptx": [
+    [
+      "https://d396qusza40orc.cloudfront.net/learning/Powerpoints/1-1_Introduction_to_the_focused_and_diffuse_mode.pptx",
+      "Introduction to the Focused and Diffuse Modes"
+    ]
+  ],
+  "pdf": [
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_641128be0c5ea9b054cc3008f37074fe_Introduction-to-the-Focused-and-Diffuse-Modes.pdf?Expires=1456358400&Signature=Li3AeGJVex87g4W~bPGA2uKDgTxNA~itdHcddALNuamSDDMJtmOwa4TX83MYcBlhrG2UySjTMeA0njVk8hnJh5SnbNlT7VTsOgywM54fWoOWHXGr2b1sYTLHIjQemJorMinemxnHDY2whxytvp5GFSYDExgCHmXlzvw2KGJUCSw_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "Introduction to the Focused and Diffuse Modes"
+    ],
+    [
+      "https://d3c33hcgiwev3.cloudfront.net/_a0393b8c8f798d7230184f965ef5142b_Introduction-to-the-Focused-and-Diffuse-Modes-Script.pdf?Expires=1456358400&Signature=hmtU4SPPw~m8zTg7BV1Nr5MSLjIicJjvwQozu04zGAh8VF1uwfDnZUZUFUBc~8xRhtSdeoMxvxjSq5Eo4eA56KfBc9woSv~3rjFYSnMwMq9~-dC4UbaDEE74lbT68jJEOKmAOPH6cPekgfwIBgQgDEaBUfa~BgwKSAdozBrbP78_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+      "Introduction to the Focused and Diffuse Modes Script"
+    ]
+  ]
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-1.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-1.json
@@ -1,0 +1,13 @@
+{
+  "paging": null,
+  "elements": [
+    {
+      "typeName": "asset",
+      "definition": {
+        "assetId": "XcOqP5SKEeWEzxLvpoXzuQ"
+      },
+      "id": "Yry0spSKEeW8oA5fR3afVQ"
+    }
+  ],
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-2.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-2.json
@@ -1,0 +1,15 @@
+{
+  "paging": null,
+  "elements": [
+    {
+      "url": {
+        "url": "https://d3c33hcgiwev3.cloudfront.net/_641128be0c5ea9b054cc3008f37074fe_Introduction-to-the-Focused-and-Diffuse-Modes.pdf?Expires=1456358400&Signature=Li3AeGJVex87g4W~bPGA2uKDgTxNA~itdHcddALNuamSDDMJtmOwa4TX83MYcBlhrG2UySjTMeA0njVk8hnJh5SnbNlT7VTsOgywM54fWoOWHXGr2b1sYTLHIjQemJorMinemxnHDY2whxytvp5GFSYDExgCHmXlzvw2KGJUCSw_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+        "expires": 1456358400000
+      },
+      "typeName": "generic",
+      "name": "Introduction to the Focused and Diffuse Modes.pdf",
+      "id": "XcOqP5SKEeWEzxLvpoXzuQ"
+    }
+  ],
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-3.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-3.json
@@ -1,0 +1,14 @@
+{
+  "paging": null,
+  "elements": [
+    {
+      "typeName": "url",
+      "definition": {
+        "url": "https://d396qusza40orc.cloudfront.net/learning/Powerpoints/1-1_Introduction_to_the_focused_and_diffuse_mode.pptx",
+        "name": "Introduction to the Focused and Diffuse Modes.pptx"
+      },
+      "id": "kMQyUZSLEeWj-hLVp2Pm8w"
+    }
+  ],
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-4.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-4.json
@@ -1,0 +1,13 @@
+{
+  "paging": null,
+  "elements": [
+    {
+      "typeName": "asset",
+      "definition": {
+        "assetId": "wH1ij5mJEeW94QqFqUGMOQ"
+      },
+      "id": "xkAloZmJEeWjYA4jOOgP8Q"
+    }
+  ],
+  "linked": null
+}

--- a/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-5.json
+++ b/coursera/test/fixtures/json/supplement-open-course-assets-typename-url-reply-5.json
@@ -1,0 +1,15 @@
+{
+  "paging": null,
+  "elements": [
+    {
+      "url": {
+        "url": "https://d3c33hcgiwev3.cloudfront.net/_a0393b8c8f798d7230184f965ef5142b_Introduction-to-the-Focused-and-Diffuse-Modes-Script.pdf?Expires=1456358400&Signature=hmtU4SPPw~m8zTg7BV1Nr5MSLjIicJjvwQozu04zGAh8VF1uwfDnZUZUFUBc~8xRhtSdeoMxvxjSq5Eo4eA56KfBc9woSv~3rjFYSnMwMq9~-dC4UbaDEE74lbT68jJEOKmAOPH6cPekgfwIBgQgDEaBUfa~BgwKSAdozBrbP78_&Key-Pair-Id=APKAJLTNE6QMUY6HBC5A",
+        "expires": 1456358400000
+      },
+      "typeName": "generic",
+      "name": "Introduction to the Focused and Diffuse Modes Script.pdf",
+      "id": "wH1ij5mJEeW94QqFqUGMOQ"
+    }
+  ],
+  "linked": null
+}

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -61,13 +61,36 @@ def test_ondemand_programming_supplement_three_assets(get_page, course):
 
 
 @patch('coursera.api.get_page')
-def test_extract_links_from_lecture_assets(get_page, course):
+def test_extract_links_from_lecture_assets_typename_asset(get_page, course):
     open_course_assets_reply = slurp_fixture('json/supplement-open-course-assets-reply.json')
     api_assets_v1_reply = slurp_fixture('json/supplement-api-assets-v1-reply.json')
     get_page.side_effect = [open_course_assets_reply, api_assets_v1_reply]
 
     expected_output = json.loads(slurp_fixture('json/supplement-extract-links-from-lectures-output.json'))
     assets = ['giAxucdaEeWJTQ5WTi8YJQ']
+    output = course._extract_links_from_lecture_assets(assets)
+    output = json.loads(json.dumps(output))
+    assert expected_output == output
+
+
+@patch('coursera.api.get_page')
+def test_extract_links_from_lecture_assets_typname_url_and_asset(get_page, course):
+    """
+    This test makes sure that _extract_links_from_lecture_assets grabs url
+    links both from typename == 'asset' and == 'url'.
+    """
+    get_page.side_effect = [
+        slurp_fixture('json/supplement-open-course-assets-typename-url-reply-1.json'),
+        slurp_fixture('json/supplement-open-course-assets-typename-url-reply-2.json'),
+        slurp_fixture('json/supplement-open-course-assets-typename-url-reply-3.json'),
+        slurp_fixture('json/supplement-open-course-assets-typename-url-reply-4.json'),
+        slurp_fixture('json/supplement-open-course-assets-typename-url-reply-5.json'),
+    ]
+
+    expected_output = json.loads(slurp_fixture('json/supplement-extract-links-from-lectures-url-asset-output.json'))
+    assets = ['Yry0spSKEeW8oA5fR3afVQ',
+              'kMQyUZSLEeWj-hLVp2Pm8w',
+              'xkAloZmJEeWjYA4jOOgP8Q']
     output = course._extract_links_from_lecture_assets(assets)
     output = json.loads(json.dumps(output))
     assert expected_output == output

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -20,6 +20,7 @@ BeautifulSoup = lambda page: BeautifulSoup_(page, 'html5lib')
 from .define import COURSERA_URL
 
 from six.moves import html_parser
+from six import iteritems
 
 #  six.moves doesn’t support urlparse
 if six.PY3:  # pragma: no cover
@@ -139,3 +140,21 @@ def make_coursera_absolute_url(url):
         return urljoin(COURSERA_URL, url)
 
     return url
+
+
+def extend_supplement_links(destination, source):
+    """
+    Extends (merges) two dictionaries with supplement_links.
+
+    @param destination: Destination dictionary that will be extended.
+    @type destination: @see CourseraOnDemand._extract_links_from_text
+
+    @param source: Source dictionary that will be used to extend
+        destination dictionary.
+    @type source: @see CourseraOnDemand._extract_links_from_text
+    """
+    for key, value in iteritems(source):
+        if key not in destination:
+            destination[key] = value
+        else:
+            destination[key].extend(value)

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -144,7 +144,9 @@ def make_coursera_absolute_url(url):
 
 def extend_supplement_links(destination, source):
     """
-    Extends (merges) two dictionaries with supplement_links.
+    Extends (merges) destination dictionary with supplement_links
+    from source dictionary. Values are expected to be lists, or any
+    data structure that has `extend` method.
 
     @param destination: Destination dictionary that will be extended.
     @type destination: @see CourseraOnDemand._extract_links_from_text


### PR DESCRIPTION
Add code to handle elements of typename=='url'

We've seen elements of typename=='asset' before. Some courses
include asset files as a special entity, element typename=='asset'.
For such elements additional API call is required.

Another way to include an asset file is to use typename=='url' asset.
In this case you can directly include URL to a file like this:

``` js
{'elements': [{'definition': {'name': 'What motivates you.pptx',
                              'url': 'https://d396qusza40orc.cloudfront.net/learning/Powerpoints/2-4A_What_motivates_you.pptx'},
               'id': '0hixqpWJEeWQkg5xdHApow',
               'typeName': 'url'}],
 'linked': None,
 'paging': None}
```

Notice, however, that such assets don't always contain links to files.
Certain course authors put there regular links as follows:

``` js
{'elements': [{'definition': {'name': 'Here is a quick list of some histogram '
                                      'distance functions.',
                              'url': 'http://stats.stackexchange.com/questions/7400/how-to-assess-the-similarity-of-two-histograms'},
               'id': '5b7TusBgEeWdnhIHQKZtcQ',
               'typeName': 'url'}],
 'linked': None,
 'paging': None}
```

fix #442 