### PR TITLE
File names too long

### DIFF
--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -521,7 +521,7 @@ def download_lectures(downloader,
                 else:
                     lecfn = os.path.join(
                         sec, format_resource(lecnum + 1, lecname, title, fmt))
-
+                lecfn = lecfn[0:250]
                 if overwrite or not os.path.exists(lecfn) or resume:
                     if not skip_download:
                         logging.info('Downloading: %s', lecfn)


### PR DESCRIPTION
## Proposed changes

Some file names being generated by the script from coursera courses were too long for the macosx filesystem (and apparently Windows - see #476), so the downloads could not complete. This commit truncates those filenames and allows download of the courses.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
      - This adds no more complaints to lint - it's certainly not compliant

It's not clear how to make an adequate test of the feature of the bugfix.

## Further comments

I'm not a python programmer, but this fixed my problem (and hopefully other people's from #476).