### PR TITLE
Make SElinux not complain about write access in /courses

### DIFF
--- a/deploy/download.sh
+++ b/deploy/download.sh
@@ -7,9 +7,9 @@ if [ ! -e ~/courses ]; then
 fi
 
 if groups | grep -q "docker" ; then
-    docker run --rm --name coursera -v ~/courses:/courses coursera-img \
+    docker run --rm --name coursera -v ~/courses:/courses:Z coursera-img \
                coursera-dl -n --path /courses $COURSES
 else
-    sudo docker run --rm --name coursera -v ~/courses:/courses coursera-img \
+    sudo docker run --rm --name coursera -v ~/courses:/courses:Z coursera-img \
                     coursera-dl -n --path /courses $COURSES
 fi


### PR DESCRIPTION
This PR addresses an issue that happened on my CentOS 7, and presumably could happen on other SElinux-enabled environments

## Proposed changes

As per title, SElinux can complain about writing in the root folder /courses. Following the explanation [here](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/), using the flag Z when setting up volumes sets the correct context labels and SElinux is happy. 

This change does not touch any other functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

