### PR TITLE
Cleaning filenames in more places

### DIFF
--- a/coursera/downloaders.py
+++ b/coursera/downloaders.py
@@ -385,6 +385,7 @@ class NativeDownloader(Downloader):
             chunk_sz = 1048576
             progress = DownloadProgress(content_length)
             progress.start()
+
             f = open(filename, 'ab') if resume else open(filename, 'wb')
             while True:
                 data = r.raw.read(chunk_sz, decode_content=True)

--- a/coursera/downloaders.py
+++ b/coursera/downloaders.py
@@ -61,6 +61,13 @@ class Downloader(object):
 
         logging.debug('filename after get parameter removal: <%s>.', filename)
 
+        # FIXME (rbrito): This is pretty arbitrary and quite possibly wrong,
+        # as we don't even take extensions into account.
+        if len(filename) > 255:
+            filename = filename[:252] + '...'
+
+        logging.debug('filename after trimming: <%s>', filename)
+
         try:
             self._start_download(url, filename, resume)
         except KeyboardInterrupt as e:

--- a/coursera/downloaders.py
+++ b/coursera/downloaders.py
@@ -12,12 +12,15 @@ from __future__ import print_function
 import logging
 import math
 import os
+import re
 import requests
 import subprocess
 import sys
 import time
 
 from six import iteritems
+
+from .utils import clean_filename
 
 
 class Downloader(object):
@@ -45,6 +48,18 @@ class Downloader(object):
         Download the given url to the given file. When the download
         is aborted by the user, the partially downloaded file is also removed.
         """
+
+        logging.debug('"raw" filename: <%s>.', filename)
+        filename = clean_filename(filename, minimal_change=True, keep_slashes=True)
+        logging.debug('filename after cleaning: <%s>.', filename)
+
+        # FIXME (rbrito): This should, perhaps, be included clean_filename
+        # m = re.match(r'^(.+)\?(.+=.+&?)*$', filename)
+        m = re.match(r'^([^?#]+)[?#]?.*$', filename)
+        if m != None:
+            filename = m.group(1)
+
+        logging.debug('filename after get parameter removal: <%s>.', filename)
 
         try:
             self._start_download(url, filename, resume)

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -61,7 +61,7 @@ def clean_filename(s, minimal_change=False, keep_slashes=False):
     """
     Sanitize a string to be used as a filename.
 
-    If minimal_change is set to true, then we only strip the bare minimum of
+    If minimal_change is set to True, then we only strip the bare minimum of
     characters that are problematic for filesystems (namely, ':', '/' and
     '\x00', '\n').
 


### PR DESCRIPTION
# Proposed changes

These are some tested-in-my-use (not formally tested via a testsuite, which may be broken), and definitely some WIP and I see that I still have to catch up with the latest changes in the code, but I guess that a more extensive use the `clean_filename` function would be useful.

Please, don't merge it yet (it can't be merged automatically, since there are merge conflicts, after all). It is just code that I had sitting around here and that I felt that others could use as inspiration (if it is not already implemented in the current master branch).

Let's discuss how to make it better (**if** it is needed at all).
## Types of changes

None of the template options applies (I guess that I should send a pull request with changes).

These changes, when merged, diverges from the previous behavior and, depending on who you ask, downloading gigabytes of materials is a breakage, since the filenames will differ.
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
### Reviewers

Please @balta2ar, @iemejia, @mxamin and others, please take a look at my poor code. It would help if @GlowingCrystallineEntity could see if any of these changes break things badly under Windows.

If you know the person who can review your code please add a @mention.
