### PR TITLE
Parallel resource downloader and separate course structure iteration

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,5 @@
+--exclude=.tox
+--exclude=build
+--exclude=*.patch
+--exclude=*.html
+--exclude=*.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *~
 .DS_Store
 _cache/
+.cache/
+.vagrant/
 .coverage
 /cover/
 /htmlcov/
@@ -9,6 +11,8 @@ _cache/
 /dist/
 *.egg-info
 .tox
+tags
+tmp
 
 # virtualenv folders
 venv2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,26 @@ If you need to change the test suite, explain in the commit message why it
 needs to be changed (e.g., the page layout or the authentication methods
 from coursera changed, or they implemented a new kind of course).
 
+## Using tox and pyenv
+
+Running only py.test is okay for one-time check, but as it runs on your
+currently active Python installation, you're only checking the script on one
+Python version. A combination of tox + pyenv will allow you to run tests on many
+Python versions easily.
+
+First, install tox (listed in requirements-dev.txt) and pyenv (see their manual:
+[pyenv installation](https://github.com/yyuu/pyenv#installation). Make sure to
+activate pyenv or start a new shell. Then, install Python versions and run tox:
+
+    pyenv install 3.5.1
+    pyenv install 3.4.4
+    pyenv install 3.3.6
+    pyenv install 3.2
+    pyenv install 2.7.5
+    pyenv install 2.6.9
+    pyenv local 3.5.1 3.4.4 3.3.6 3.2 2.7.5 2.6.9
+    tox
+
 # Check for potential bugs
 
 Please, help keep the code tidy by checking for any potential bugs with the
@@ -203,13 +223,13 @@ There are many other tricks/steps in the git workflow, but these are the
 basics that I (@rbrito) think that will suffice for a start.  If you want a
 few details more, feel free to ask me to include them here.
 
-# Release process
+# Release procedure
 
 This section is for project maintainers.
 
 DRAFT
 
-1. Run tests locally
+1. Run tests locally. Use tox to run tests on all supported Python versions.
 2. Run the script on several courses to check sanity
 3. Update CHANGELOG.md, increment version, put what you've added to the
    changelog into commit message. This way it gets it way into releases page

--- a/coursera/commandline.py
+++ b/coursera/commandline.py
@@ -44,6 +44,14 @@ def parse_args(args=None):
                              default=None,
                              help='coursera password')
 
+    group_basic.add_argument('--jobs',
+                             dest='jobs',
+                             action='store',
+                             default=1,
+                             type=int,
+                             help='number of parallel jobs to use for '
+                             'downloading resources. (Default: 1)')
+
     group_basic.add_argument('-b',  # FIXME: kill this one-letter option
                              '--preview',
                              dest='preview',

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -63,6 +63,7 @@ from .cookies import (
 from .define import (CLASS_URL, ABOUT_URL, PATH_CACHE)
 from .downloaders import get_downloader
 from .workflow import CourseraDownloader
+from .parallel import ConsecutiveDownloader, ParallelDownloader
 from .utils import (clean_filename, get_anchor_format, mkdir_p, fix_url,
                     print_ssl_error_message,
                     decode_input, BeautifulSoup, is_debug_run)
@@ -134,6 +135,8 @@ def download_on_demand_class(args, class_name):
             json.dump(modules, file_object, indent=4)
 
     downloader = get_downloader(session, class_name, args)
+    downloader_wrapper = ParallelDownloader(downloader, args.jobs) \
+        if args.jobs > 1 else ConsecutiveDownloader(downloader)
 
     # obtain the resources
 
@@ -142,7 +145,7 @@ def download_on_demand_class(args, class_name):
         ignored_formats = args.ignore_formats.split(",")
 
     course_downloader = CourseraDownloader(
-        downloader,
+        downloader_wrapper,
         commandline_args=args,
         class_name=class_name,
         path=args.path,

--- a/coursera/parallel.py
+++ b/coursera/parallel.py
@@ -1,0 +1,50 @@
+import abc
+from multiprocessing.dummy import Pool
+
+
+class AbstractDownloader(object):
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, file_downloader):
+        super(AbstractDownloader, self).__init__()
+        self._file_downloader = file_downloader
+
+    @abc.abstractmethod
+    def download(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def join(self):
+        raise NotImplementedError()
+
+    def _download_wrapper(self, url, *args, **kwargs):
+        try:
+            return url, self._file_downloader.download(url, *args, **kwargs)
+        except Exception as e:
+            return url, e
+
+
+class ConsecutiveDownloader(AbstractDownloader):
+    def download(self, callback, url, *args, **kwargs):
+        _, result = self._download_wrapper(url, *args, **kwargs)
+        callback(url, result)
+        return result
+
+    def join(self):
+        pass
+
+
+class ParallelDownloader(AbstractDownloader):
+    def __init__(self, file_downloader, processes):
+        super(ParallelDownloader, self).__init__(file_downloader)
+        self._pool = Pool(processes=processes)
+
+    def download(self, callback, url, *args, **kwargs):
+        callback_wrapper = lambda payload: callback(*payload)
+        return self._pool.apply_async(
+            self._download_wrapper, (url,) + args, kwargs,
+            callback=callback_wrapper)
+
+    def join(self):
+        self._pool.close()
+        self._pool.join()

--- a/coursera/test/test_workflow.py
+++ b/coursera/test/test_workflow.py
@@ -1,0 +1,154 @@
+import pytest
+import requests
+from requests.exceptions import RequestException
+
+from coursera.workflow import CourseraDownloader, _iter_modules, _walk_modules
+from coursera.commandline import parse_args
+from coursera.parallel import ConsecutiveDownloader, ParallelDownloader
+from coursera.downloaders import Downloader
+
+
+class MockedCommandLineArgs(object):
+    """
+    This mock uses default arguments from parse_args and allows to overwrite
+    them in constructor.
+    """
+    def __init__(self, **kwargs):
+        args = parse_args('-u username -p password test_class'.split())
+        self.__dict__.update(args.__dict__)
+        self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        return self.__dict__.__repr__()
+
+
+class MockedFailingDownloader(Downloader):
+    """
+    This mock will raise whatever exception you pass to it in constructor
+    in _start_download method. Pass None to prevent any exception.
+    """
+    def __init__(self, exception_to_throw):
+        self._exception_to_throw = exception_to_throw
+
+    def _start_download(self, *args, **kwargs):
+        if self._exception_to_throw is None:
+            return
+        raise self._exception_to_throw
+
+
+TEST_URL = "https://www.coursera.org/api/test-url"
+
+
+def make_test_modules():
+    modules = [
+        ["section1",
+         [
+             ["module1",
+              [
+                  ["lecture1",
+                   {"en.txt": [
+                       [TEST_URL,
+                        "title"
+                       ]
+                   ]
+                   }
+                  ]
+              ]
+             ]
+         ]
+        ]
+    ]
+    return modules
+
+
+@pytest.mark.parametrize(
+    'expected_failed_urls,exception_to_throw,downloader_wrapper_class', [
+        ([], None, ConsecutiveDownloader),
+        ([], None, ParallelDownloader),
+        ([TEST_URL], RequestException('Test exception'), ConsecutiveDownloader),
+        ([TEST_URL], RequestException('Test exception'), ParallelDownloader),
+        ([TEST_URL], Exception('Test exception'), ConsecutiveDownloader),
+        ([TEST_URL], Exception('Test exception'), ParallelDownloader),
+        ([TEST_URL], ValueError('Test exception'), ConsecutiveDownloader),
+        ([TEST_URL], ValueError('Test exception'), ParallelDownloader),
+        ([TEST_URL], AttributeError('Test exception'), ConsecutiveDownloader),
+        ([TEST_URL], AttributeError('Test exception'), ParallelDownloader),
+    ]
+)
+def test_failed_urls_are_collected(expected_failed_urls,
+                                   exception_to_throw,
+                                   downloader_wrapper_class):
+    """
+    This test makes sure that if there was an exception in the file downloader,
+    downloader wrapper will intercept it and course downloader will record
+    the problematic URL.
+    """
+    file_downloader = MockedFailingDownloader(exception_to_throw)
+    course_downloader = CourseraDownloader(
+        downloader=downloader_wrapper_class(file_downloader),
+        commandline_args=MockedCommandLineArgs(overwrite=True),
+        class_name='test_class',
+        path='',
+        ignored_formats=None,
+        disable_url_skipping=False)
+    modules = make_test_modules()
+
+    course_downloader.download_modules(modules)
+    assert expected_failed_urls == course_downloader.failed_urls
+
+
+def test_iter_modules():
+    """
+    Test that all modules are iterated and intermediate values are formatted
+    correctly. Filtering is not tested at the moment.
+    """
+    modules = make_test_modules()
+    args = MockedCommandLineArgs()
+
+    expected_output = [
+        (0, '01_section1'),
+        (0, 'test_class/01_section1/01_module1'),
+        (0, 'lecture1', 'en.txt', 'title'),
+        ('en.txt', 'https://www.coursera.org/api/test-url', 'title')
+    ]
+    collected_output = []
+
+    for module in _iter_modules(modules=modules, class_name='test_class',
+                                path='', ignored_formats=None, args=args):
+        collected_output.append((module.index, module.name))
+        for section in module.sections:
+            collected_output.append((section.index, section.dir))
+            for lecture in section.lectures:
+                for resource in lecture.resources:
+                    collected_output.append((lecture.index, lecture.name,
+                                             resource.fmt, resource.title))
+                    collected_output.append((resource.fmt, resource.url, resource.title))
+
+    assert expected_output == collected_output
+
+def test_walk_modules():
+    """
+    Test _walk_modules, a flattened version of _iter_modules.
+    """
+    modules = make_test_modules()
+    args = MockedCommandLineArgs()
+
+    expected_output = [
+        (0, '01_section1',
+         0, 'test_class/01_section1/01_module1',
+         0, 'lecture1', 'test_class/01_section1/01_module1/01_lecture1_title.en.txt',
+         'https://www.coursera.org/api/test-url')]
+    collected_output = []
+
+    for module, section, lecture, resource in _walk_modules(
+            modules=modules, class_name='test_class',
+            path='', ignored_formats=None, args=args):
+
+        collected_output.append(
+            (module.index, module.name,
+             section.index, section.dir,
+             lecture.index, lecture.name, lecture.filename(resource.fmt, resource.title),
+             resource.url)
+        )
+
+    assert expected_output == collected_output

--- a/coursera/test/test_workflow.py
+++ b/coursera/test/test_workflow.py
@@ -1,3 +1,4 @@
+from os.path import normpath
 import pytest
 import requests
 from requests.exceptions import RequestException
@@ -107,7 +108,7 @@ def test_iter_modules():
 
     expected_output = [
         (0, '01_section1'),
-        (0, 'test_class/01_section1/01_module1'),
+        (0, normpath('test_class/01_section1/01_module1')),
         (0, 'lecture1', 'en.txt', 'title'),
         ('en.txt', 'https://www.coursera.org/api/test-url', 'title')
     ]
@@ -135,7 +136,7 @@ def test_walk_modules():
 
     expected_output = [
         (0, '01_section1',
-         0, 'test_class/01_section1/01_module1',
+         0, normpath('test_class/01_section1/01_module1'),
          0, 'lecture1', 'test_class/01_section1/01_module1/01_lecture1_title.en.txt',
          'https://www.coursera.org/api/test-url')]
     collected_output = []

--- a/coursera/test/test_workflow.py
+++ b/coursera/test/test_workflow.py
@@ -137,7 +137,7 @@ def test_walk_modules():
     expected_output = [
         (0, '01_section1',
          0, normpath('test_class/01_section1/01_module1'),
-         0, 'lecture1', 'test_class/01_section1/01_module1/01_lecture1_title.en.txt',
+         0, 'lecture1', normpath('test_class/01_section1/01_module1/01_lecture1_title.en.txt'),
          'https://www.coursera.org/api/test-url')]
     collected_output = []
 

--- a/coursera/workflow.py
+++ b/coursera/workflow.py
@@ -96,6 +96,22 @@ def _iter_modules(modules, class_name, path, ignored_formats, args):
         yield IterModule(index, module)
 
 
+def _walk_modules(modules, class_name, path, ignored_formats, args):
+    """
+    Helper generator that traverses modules in returns a flattened
+    iterator.
+    """
+    for module in _iter_modules(modules=modules,
+                                class_name=class_name,
+                                path=path,
+                                ignored_formats=ignored_formats,
+                                args=args):
+        for section in module.sections:
+            for lecture in section.lectures:
+                for resource in lecture.resources:
+                    yield module, section, lecture, resource
+
+
 class CourseDownloader(object):
     __metaclass__ = abc.ABCMeta
 

--- a/coursera/workflow.py
+++ b/coursera/workflow.py
@@ -15,6 +15,87 @@ from .filter import find_resources_to_get, skip_format_url
 from .define import IN_MEMORY_MARKER
 
 
+def _iter_modules(modules, class_name, path, ignored_formats, args):
+    """
+    This huge function generates a hierarchy with hopefully more
+    clear structure of modules/sections/lectures.
+    """
+    file_formats = args.file_formats
+    lecture_filter = args.lecture_filter
+    resource_filter = args.resource_filter
+    section_filter = args.section_filter
+    verbose_dirs = args.verbose_dirs
+    combined_section_lectures_nums = args.combined_section_lectures_nums
+
+    class IterModule(object):
+        def __init__(self, index, module):
+            self.index = index
+            self.name = '%02d_%s' % (index + 1, module[0])
+            self._module = module
+
+        @property
+        def sections(self):
+            sections = self._module[1]
+            for (secnum, (section, lectures)) in enumerate(sections):
+                if section_filter and not re.search(section_filter, section):
+                    logging.debug('Skipping b/c of sf: %s %s',
+                                  section_filter, section)
+                    continue
+
+                yield IterSection(self, secnum, section, lectures)
+
+    class IterSection(object):
+        def __init__(self, module_iter, secnum, section, lectures):
+            self.index = secnum
+            self.dir = os.path.join(
+                path, class_name, module_iter.name,
+                format_section(secnum + 1, section,
+                               class_name, verbose_dirs))
+            self._lectures = lectures
+
+        @property
+        def lectures(self):
+            for (lecnum, (lecname, lecture)) in enumerate(self._lectures):
+                if lecture_filter and not re.search(lecture_filter, lecname):
+                    logging.debug('Skipping b/c of lf: %s %s',
+                                  lecture_filter, lecname)
+                    continue
+
+                yield IterLecture(self, lecnum, lecname, lecture)
+
+    class IterLecture(object):
+        def __init__(self, section_iter, lecnum, lecname, lecture):
+            self.index = lecnum
+            self.name = lecname
+            self._lecture = lecture
+            self._section_iter = section_iter
+
+        def filename(self, fmt, title):
+            lecture_filename = get_lecture_filename(
+                combined_section_lectures_nums,
+                self._section_iter.dir, self._section_iter.index,
+                self.index, self.name, title, fmt)
+            return lecture_filename
+
+        @property
+        def resources(self):
+            resources_to_get = find_resources_to_get(
+                self._lecture, file_formats, resource_filter,
+                ignored_formats)
+
+            for fmt, url, title in resources_to_get:
+                yield IterResource(fmt, url, title)
+
+    class IterResource(object):
+        def __init__(self, fmt, url, title):
+            self.fmt = fmt
+            self.url = url
+            self.title = title
+
+    for index, module in enumerate(modules):
+        yield IterModule(index, module)
+
+
 class CourseDownloader(object):
     __metaclass__ = abc.ABCMeta
 
@@ -46,122 +127,44 @@ class CourseraDownloader(CourseDownloader):
         self.skipped_urls = [] if disable_url_skipping else None
         self.failed_urls = []
 
-        self._last_update = -1
-
     def download_modules(self, modules):
         completed = True
-        for idx, module in enumerate(modules):
-            module_name = '%02d_%s' % (idx + 1, module[0])
-            sections = module[1]
-            result = self._download_sections(module_name, sections)
-            completed = completed and result
+        modules = _iter_modules(
+            modules, self._class_name, self._path,
+            self._ignored_formats, self._args)
 
-        # Wait for all downloads to complete
-        self._downloader.join()
+        for module in modules:
+            last_update = -1
+            for section in module.sections:
+                if not os.path.exists(section.dir):
+                    mkdir_p(normalize_path(section.dir))
 
-        # Iterate over modules again to apply playlist creation/other hooks
-        # after download has finished
-        self._apply_postprocessing(modules)
-
-        return completed
-
-    def _apply_postprocessing(self, modules):
-        """
-        Apply postprocessing hooks to downloaded modules.
-        """
-        section_filter = self._args.section_filter
-        hooks = self._args.hooks
-        playlist = self._args.playlist
-        verbose_dirs = self._args.verbose_dirs
-
-        for idx, module in enumerate(modules):
-            module_name = '%02d_%s' % (idx + 1, module[0])
-            sections = module[1]
-
-            for (secnum, (section, lectures)) in enumerate(sections):
-                if section_filter and not re.search(section_filter, section):
-                    continue
-
-                section_dir = os.path.join(
-                    self._path, self._class_name, module_name,
-                    format_section(secnum + 1, section,
-                                   self._class_name, verbose_dirs))
+                for lecture in section.lectures:
+                    for resource in lecture.resources:
+                        lecture_filename = normalize_path(
+                            lecture.filename(resource.fmt, resource.title))
+                        last_update = self._handle_resource(
+                            resource.url, resource.fmt, lecture_filename,
+                            self._download_completion_handler, last_update)
 
                 # After fetching resources, create a playlist in M3U format with the
                 # videos downloaded.
-                if playlist:
-                    create_m3u_playlist(section_dir)
+                if self._args.playlist:
+                    create_m3u_playlist(section.dir)
 
-                if hooks:
-                    original_dir = os.getcwd()
-                    for hook in hooks:
-                        logging.info('Running hook %s for section %s.', hook, section_dir)
-                        os.chdir(section_dir)
-                        subprocess.call(hook)
-                    os.chdir(original_dir)
+                if self._args.hooks:
+                    self._run_hooks(section, self._args.hooks)
 
-    def _download_sections(self, module_name, sections):
-        """
-        Download lecture resources described by sections.
+            # if we haven't updated any files in 1 month, we're probably
+            # done with this course
+            completed = completed and is_course_complete(last_update)
 
-        Returns True if the class appears completed, False otherwise.
-        """
-        self._last_update = -1
-
-        section_filter = self._args.section_filter
-        verbose_dirs = self._args.verbose_dirs
-
-        for (secnum, (section, lectures)) in enumerate(sections):
-            if section_filter and not re.search(section_filter, section):
-                logging.debug('Skipping b/c of sf: %s %s', section_filter,
-                              section)
-                continue
-
-            section_dir = os.path.join(
-                self._path, self._class_name, module_name,
-                format_section(secnum + 1, section,
-                               self._class_name, verbose_dirs))
-
-            self._download_lectures(lectures, secnum, section_dir)
-
-        # if we haven't updated any files in 1 month, we're probably
-        # done with this course
-        is_complete = is_course_complete(self._last_update)
-        if is_complete:
+        if completed:
             logging.info('COURSE PROBABLY COMPLETE: ' + self._class_name)
 
-        return is_complete
-
-    def _download_lectures(self, lectures, secnum, section_dir):
-        lecture_filter = self._args.lecture_filter
-        file_formats = self._args.file_formats
-        resource_filter = self._args.resource_filter
-        combined_section_lectures_nums = self._args.combined_section_lectures_nums
-
-        for (lecnum, (lecname, lecture)) in enumerate(lectures):
-            if lecture_filter and not re.search(lecture_filter,
-                                                lecname):
-                logging.debug('Skipping b/c of lf: %s %s', lecture_filter,
-                              lecname)
-                continue
-
-            if not os.path.exists(section_dir):
-                mkdir_p(normalize_path(section_dir))
-
-            resources_to_get = find_resources_to_get(lecture,
-                                                     file_formats,
-                                                     resource_filter,
-                                                     self._ignored_formats)
-
-            # write lecture resources
-            for fmt, url, title in resources_to_get:
-                lecture_filename = get_lecture_filename(
-                    combined_section_lectures_nums,
-                    section_dir, secnum, lecnum, lecname, title, fmt)
-
-                lecture_filename = normalize_path(lecture_filename)
-                self._handle_resource(url, fmt, lecture_filename,
-                                      self._download_completion_handler)
+        # Wait for all downloads to complete
+        self._downloader.join()
+        return completed
 
     def _download_completion_handler(self, url, result):
         if isinstance(result, requests.exceptions.RequestException):
@@ -169,22 +172,32 @@ class CourseraDownloader(CourseDownloader):
                           'downloading URL %s: %s', url, str(result))
             self.failed_urls.append(url)
         elif isinstance(result, Exception):
-            logging.error('Unknown exception occurred: %s' % result)
+            logging.error('Unknown exception occurred: %s', result)
             self.failed_urls.append(url)
 
-    def _handle_resource(self, url, fmt, lecture_filename, callback):
+    def _handle_resource(self, url, fmt, lecture_filename, callback, last_update):
         """
         Handle resource. This function builds up resource file name and
         downloads it if necessary.
 
-        @param fmt: Format of the resource (pdf, csv, etc)
-        @type fmt: str
-
         @param url: URL of the resource.
         @type url: str
 
+        @param fmt: Format of the resource (pdf, csv, etc)
+        @type fmt: str
+
+        @param lecture_filename: File name of the lecture.
+        @type lecture_filename: str
+
+        @param callback: Callback that will be called when file has been
+            downloaded. It will be called even if exception occurred.
+        @type callback: callable(url, result) where result may be Exception
+
+        @param last_update: Timestamp of the newest file so far.
+        @type last_update: int
+
         @return: Updated latest mtime.
-        @rtype: timestamp
+        @rtype: int
         """
         overwrite = self._args.overwrite
         resume = self._args.resume
@@ -206,10 +219,20 @@ class CourseraDownloader(CourseDownloader):
                         self._downloader.download(callback, url, lecture_filename, resume=resume)
             else:
                 open(lecture_filename, 'w').close()  # touch
-            self._last_update = time.time()
+            last_update = time.time()
         else:
             logging.info('%s already downloaded', lecture_filename)
             # if this file hasn't been modified in a long time,
             # record that time
-            self._last_update = max(self._last_update,
-                                    os.path.getmtime(lecture_filename))
+            last_update = max(last_update,
+                              os.path.getmtime(lecture_filename))
+        return last_update
+
+    def _run_hooks(self, section, hooks):
+        original_dir = os.getcwd()
+        for hook in hooks:
+            logging.info('Running hook %s for section %s.',
+                         hook, section.dir)
+            os.chdir(section.dir)
+            subprocess.call(hook)
+        os.chdir(original_dir)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-xdist
 mock>=1.0.1
 coverage>=3.7
 keyrings.alt
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.1.3
-html5lib>=1.0b2
+html5lib>=1.0b2,<=1.0b8
 requests>=2.10.0
 six>=1.5.0
 urllib3>=1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py26,py27,py33,py34,py35
 
 [testenv]
 downloadcache = .tox/_download/
@@ -7,7 +7,7 @@ downloadcache = .tox/_download/
 deps =
     beautifulsoup4>=4.1.3
     coverage>=3.7
-    html5lib>=1.0b2
+    html5lib>=1.0b2,<=1.0b8
     mock>=1.0.1
     pyasn1>=0.1.7
     pytest>=2.5
@@ -17,3 +17,7 @@ deps =
     keyrings.alt>=1.1
 
 commands = py.test -v --junitxml={envlogdir}/result.xml coursera/test
+# Original command: install_command = pip install {opts} {packages}
+# {opts} is remove to prevent passing option "--download-cache" to pip
+# which is already gone.
+install_command = pip install {packages}


### PR DESCRIPTION
This pull request brings two changes:

1. It implements parallel and consecutive (sequential) downloaders. They were meant to be completely interchangeable. This has slightly affected CourseraDownloader's logic which now also needs to call `join()`, but I hope it's worth it as now resources can be downloaded in parallel. Exceptions are propagated back from downloader thread into the main thread. The implementation is partially inspired by #313. Related #85.
2. Course iteration logic has been extracted into a set of helper iterator classes. This allows for cleaner code in the workflow/downloader. I've always been daunted by the complexity of the downloader code and that it mixes all sorts of things: iteration, filtering, various flag checks, and an actual download. Please pay attention to this part as on one hand I tried to separate concerns and make things modular and reusable, but I could eventually over-engineer things a bit. There is still one method that I'm not satisfied with: `_handle_resource`. Do you have any ideas on how to simplify it?

@iemejia @rbrito Please comment on the approach and what you think of these changes. Thank you!

Related: #546.