### PR TITLE
Add support for quiz and exam download

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -91,8 +91,6 @@ class QuizExamToMarkupConverter(object):
             result.append('<hr>')
 
         return '\n'.join(result)
-        # prettifier = InstructionsPrettifier(self._session)
-        # return prettifier.prettify('\n'.join(result))
 
     def _convert_options(self, question_index, options, input_type):
         if not options:
@@ -674,8 +672,7 @@ class CourseraOnDemand(object):
 
         supplement_links = self._extract_links_from_text(text)
 
-        prettifier = MarkupToHTMLConverter(self._session)
-        instructions = (IN_MEMORY_MARKER + prettifier.prettify(text),
+        instructions = (IN_MEMORY_MARKER + self._markup_to_html(text),
                         'instructions')
         extend_supplement_links(
             supplement_links, {IN_MEMORY_EXTENSION: [instructions]})
@@ -702,7 +699,6 @@ class CourseraOnDemand(object):
         #       'definition' {
         #           'value'
 
-        prettifier = MarkupToHTMLConverter(self._session)
         for asset in dom['linked']['openCourseAssets.v1']:
             value = asset['definition']['value']
             # Supplement lecture types are known to contain both <asset> tags
@@ -711,7 +707,7 @@ class CourseraOnDemand(object):
             extend_supplement_links(
                 supplement_content, self._extract_links_from_text(value))
 
-            instructions = (IN_MEMORY_MARKER + prettifier.prettify(value),
+            instructions = (IN_MEMORY_MARKER + self._markup_to_html(value),
                             'instructions')
             extend_supplement_links(
                 supplement_content, {IN_MEMORY_EXTENSION: [instructions]})

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -15,7 +15,7 @@ from six.moves.urllib_parse import quote_plus
 
 from .utils import (BeautifulSoup, make_coursera_absolute_url,
                     extend_supplement_links, clean_url, clean_filename,
-                    is_debug_run)
+                    is_debug_run, unescape_html)
 from .network import get_reply, get_page, post_page_and_reply
 from .define import (OPENCOURSE_SUPPLEMENT_URL,
                      OPENCOURSE_PROGRAMMING_ASSIGNMENTS_URL,
@@ -47,10 +47,16 @@ class QuizExamToMarkupConverter(object):
     KNOWN_QUESTION_TYPES = ('mcq',
                             'checkbox',
                             'singleNumeric',
-                            'textExactMatch')
+                            'textExactMatch',
+                            'mathExpression',
+                            'regex')
 
+    # TODO: support live MathJAX preview rendering for mathExpression
+    # and regex question types
     KNOWN_INPUT_TYPES = ('textExactMatch',
-                         'singleNumeric')
+                         'singleNumeric',
+                         'mathExpression',
+                         'regex')
 
     def __init__(self, session):
         self._session = session
@@ -73,7 +79,7 @@ class QuizExamToMarkupConverter(object):
             result.append('<h3>Question %d</h3>' % (question_index + 1))
 
             # Question text
-            question_text = prompt['definition']['value']
+            question_text = unescape_html(prompt['definition']['value'])
             result.append(question_text)
 
             # Input for answer
@@ -101,7 +107,8 @@ class QuizExamToMarkupConverter(object):
         result = ['<form>']
 
         for option in options:
-            option_text = option['display']['definition']['value']
+            option_text = unescape_html(option['display']['definition']['value'])
+
             # We need to replace <text> with <span> so that answer text
             # stays on the same line with checkbox/radio button
             option_text = self._replace_tag(option_text, 'text', 'span')

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -124,18 +124,19 @@ class MarkupToHTMLConverter(object):
     def __init__(self, session):
         self._session = session
 
-    def __call__(self, text):
+    def __call__(self, markup):
         """
-        Prettify instructions text to make it more suitable for offline reading.
+        Convert instructions markup to make it more suitable for
+        offline reading.
 
-        @param text: HTML (kinda) text to prettify.
-        @type text: str
+        @param markup: HTML (kinda) markup to prettify.
+        @type markup: str
 
         @return: Prettified HTML with several markup tags replaced with HTML
             equivalents.
         @rtype: str
         """
-        soup = BeautifulSoup(text)
+        soup = BeautifulSoup(markup)
         self._convert_instructions_basic(soup)
         self._convert_instructions_images(soup)
         return soup.prettify()

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -124,6 +124,7 @@ class QuizExamToMarkupConverter(object):
 class MarkupToHTMLConverter(object):
     def __init__(self, session):
         self._session = session
+        self._asset_retriever = AssetRetriever(session)
 
     def __call__(self, markup):
         """
@@ -138,11 +139,11 @@ class MarkupToHTMLConverter(object):
         @rtype: str
         """
         soup = BeautifulSoup(markup)
-        self._convert_instructions_basic(soup)
-        self._convert_instructions_images(soup)
+        self._convert_markup_basic(soup)
+        self._convert_markup_images(soup)
         return soup.prettify()
 
-    def _convert_instructions_basic(self, soup):
+    def _convert_markup_basic(self, soup):
         """
         Perform basic conversion of instructions markup. This includes
         replacement of several textual markup tags with their HTML equivalents.
@@ -173,7 +174,7 @@ class MarkupToHTMLConverter(object):
             type_ = list_.attrs.get('bullettype', 'numbers')
             list_.name = 'ol' if type_ == 'numbers' else 'ul'
 
-    def _convert_instructions_images(self, soup):
+    def _convert_markup_images(self, soup):
         """
         Convert images of instructions markup. Images are downloaded,
         base64-encoded and inserted into <img> tags.
@@ -283,7 +284,7 @@ class Asset(namedtuple('Asset', 'id name type_name url data')):
             self.id, self.name, self.type_name, self.url)
 
 
-class AssetRetrievier(object):
+class AssetRetriever(object):
     """
     This class helps download assets by their ID.
     """

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -14,7 +14,7 @@ from six.moves.urllib_parse import quote_plus
 
 from .utils import (BeautifulSoup, make_coursera_absolute_url,
                     extend_supplement_links, clean_url, clean_filename)
-from .network import get_page, get_page_json, post_page_and_reply, post_page_json
+from .network import get_reply, get_page, get_page_json, post_page_and_reply, post_page_json
 from .define import (OPENCOURSE_SUPPLEMENT_URL,
                      OPENCOURSE_PROGRAMMING_ASSIGNMENTS_URL,
                      OPENCOURSE_ASSET_URL,
@@ -279,7 +279,7 @@ class Asset(namedtuple('Asset', 'id name type_name url data')):
     """
     __slots__ = ()
     def __repr__(self):
-        return 'Asset(id=%s, name=%s, type_name=%s, url=%s, data="<...>")' % (
+        return 'Asset(id="%s", name="%s", type_name="%s", url="%s", data="<...>")' % (
             self.id, self.name, self.type_name, self.url)
 
 
@@ -305,13 +305,13 @@ class AssetRetrievier(object):
             asset_dict = asset_map[asset_id]
             url = asset_dict['url']['url'].strip()
 
-            request = self._session.get(url)
-            if request.status_code == 200:
+            reply = get_reply(self._session, url)
+            if reply.status_code == 200:
                 result.append(Asset(id=asset_dict['id'].strip(),
                                     name=asset_dict['name'].strip(),
                                     type_name=asset_dict['typeName'].strip(),
                                     url=url,
-                                    data=request.content))
+                                    data=reply.content))
 
         return result
 

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -62,7 +62,6 @@ class QuizExamToMarkupConverter(object):
                 logging.info('Question json: %s', question_json)
                 logging.info('Please report class name, quiz name and the data'
                              ' above to coursera-dl authors')
-            print('QUESTION TYPE', question_type)
 
             prompt = question_json['variant']['definition']['prompt']
             options = question_json['variant']['definition'].get('options', [])
@@ -299,7 +298,6 @@ class CourseraOnDemand(object):
         self._session = session
         self._course_id = course_id
         self._course_name = course_name
-        print('course name', course_name)
 
         self._unrestricted_filenames = unrestricted_filenames
         self._user_id = None
@@ -338,7 +336,7 @@ class CourseraOnDemand(object):
         session_id = self._get_quiz_session_id(quiz_id)
         quiz_json = self._get_quiz_json(quiz_id, session_id)
 
-        with open('quizes/quiz-%s-%s.json' % (self._class_name, quiz_id), 'w') as f:
+        with open('quizes/quiz-%s-%s.json' % (self._course_name, quiz_id), 'w') as f:
             json.dump(quiz_json, f)
 
         return self._convert_quiz_json_to_links(quiz_json, 'quiz')

--- a/coursera/api.py
+++ b/coursera/api.py
@@ -290,7 +290,7 @@ class AssetRetrievier(object):
     def __init__(self, session):
         self._session = session
 
-    def __call__(self, asset_ids):
+    def __call__(self, asset_ids, download=True):
         result = []
 
         # Download information about assets (by IDs)
@@ -303,15 +303,20 @@ class AssetRetrievier(object):
         for asset_id in asset_ids:
             # Download each asset
             asset_dict = asset_map[asset_id]
-            url = asset_dict['url']['url'].strip()
 
-            reply = get_reply(self._session, url)
-            if reply.status_code == 200:
-                result.append(Asset(id=asset_dict['id'].strip(),
-                                    name=asset_dict['name'].strip(),
-                                    type_name=asset_dict['typeName'].strip(),
-                                    url=url,
-                                    data=reply.content))
+            url = asset_dict['url']['url'].strip()
+            data = None
+
+            if download:
+                reply = get_reply(self._session, url)
+                if reply.status_code == 200:
+                    data = reply.content
+
+            result.append(Asset(id=asset_dict['id'].strip(),
+                                name=asset_dict['name'].strip(),
+                                type_name=asset_dict['typeName'].strip(),
+                                url=url,
+                                data=data))
 
         return result
 

--- a/coursera/commandline.py
+++ b/coursera/commandline.py
@@ -137,7 +137,7 @@ def parse_args(args=None):
                                 help='disable URL skipping, all URLs will be '
                                 'downloaded (default: False)')
 
-    # Selection of material to download
+    # Parameters realated to external downloaders
     group_external_dl = parser.add_argument_group('External downloaders')
 
     group_external_dl.add_argument('--wget',

--- a/coursera/commandline.py
+++ b/coursera/commandline.py
@@ -76,6 +76,12 @@ def parse_args(args=None):
     # Selection of material to download
     group_material = parser.add_argument_group('Selection of material to download')
 
+    group_material.add_argument('--download-quizzes',
+                                dest='download_quizzes',
+                                action='store_true',
+                                default=False,
+                                help='download quiz and exam questions. (Default: False)')
+
     group_material.add_argument('--about',  # FIXME: should be --about-course
                                 dest='about',
                                 action='store_true',
@@ -137,7 +143,7 @@ def parse_args(args=None):
                                 help='disable URL skipping, all URLs will be '
                                 'downloaded (default: False)')
 
-    # Parameters realated to external downloaders
+    # Parameters related to external downloaders
     group_external_dl = parser.add_argument_group('External downloaders')
 
     group_external_dl.add_argument('--wget',

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -128,7 +128,8 @@ def download_on_demand_class(args, class_name):
                                         args.reverse,
                                         args.unrestricted_filenames,
                                         args.subtitle_language,
-                                        args.video_resolution)
+                                        args.video_resolution,
+                                        args.download_quizzes)
 
     if is_debug_run or args.cache_syllabus():
         with open(cached_syllabus_filename, 'w') as file_object:

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -221,6 +221,8 @@ def main():
                 completed_classes.append(class_name)
         except requests.exceptions.HTTPError as e:
             logging.error('HTTPError %s', e)
+            if is_debug_run():
+                logging.exception('HTTPError %s', e)
         except requests.exceptions.SSLError as e:
             logging.error('SSLError %s', e)
             print_ssl_error_message(e)

--- a/coursera/define.py
+++ b/coursera/define.py
@@ -421,7 +421,324 @@ POST_OPENCOURSE_API_QUIZ_SESSION_GET_STATE = 'https://www.coursera.org/api/openc
 #
 #POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS = 'https://www.coursera.org/api/onDemandExamSessions.v1/-N44X0IJEeWpogr5ZO8qxQ~YV0W4~10!~1467462079068/actions?includes=gradingAttempts'
 
+# Response for this request is empty. Result (session_id) should be taken
+# either from Location header or from X-Coursera-Id header.
+#
+# Request payload:
+# {"courseId":"-N44X0IJEeWpogr5ZO8qxQ","itemId":"YV0W4"}
 POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS = 'https://www.coursera.org/api/onDemandExamSessions.v1'
+
+# Sample response:
+# {
+#   "elements": [
+#     {
+#       "id": 0,
+#       "result": {
+#         "questions": [
+#           {
+#             "id": "8uUpMzm_EeaetxLgjw7H8Q@0",
+#             "question": {
+#               "type": "mcq"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nSuppose you’d like to perform nearest neighbor search from the following set of houses:</text><table rows=\"5\" columns=\"4\"><tr><td><text>\n\n\n\n\n\n</text></td><td><text>\n\n\nPrice (USD)</text></td><td><text>\n\n\nNumber of rooms</text></td><td><text>\n\n\nLot size (sq. ft.)</text></td></tr><tr><td><text>\n\n\nHouse 1</text></td><td><text>\n\n\n500000</text></td><td><text>\n\n\n3</text></td><td><text>\n\n\n1840</text></td></tr><tr><td><text>\n\n\nHouse 2</text></td><td><text>\n\n\n350000</text></td><td><text>\n\n\n2</text></td><td><text>\n\n\n1600</text></td></tr><tr><td><text>House 3</text></td><td><text>\n\n600000</text></td><td><text>\n\n4</text></td><td><text>\n\n2000</text></td></tr><tr><td><text>House 4</text></td><td><text>\n400000</text></td><td><text>\n2</text></td><td><text>\n1900</text></td></tr></table><text>\n\nSince the features come in wildly different scales, you decide to use scaled Euclidean distances. Choose the set of weights a_i (as presented in the video lecture) that properly incorporates the relative amount of variation of the feature.</text><text>Note: </text><code language=\"plain_text\">a_price = weight assigned to price (USD)\na_room  = weight assigned to number of rooms\na_lot   = weight assigned to lot size (sq.ft.)</code></co-content>"
+#                   }
+#                 },
+#                 "options": [
+#                   {
+#                     "id": "0.9109180361318947",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1, a_room = 1, a_lot = 1</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.11974743029080992",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1, a_room = 1, a_lot = 1e-6</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.8214165539451299",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e-10, a_room = 1, a_lot = 1e-6</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.6784789645868041",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e-5, a_room = 1, a_lot = 1e-3</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.9664001374497642",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e5, a_room = 1, a_lot = 1e3</text></co-content>"
+#                       }
+#                     }
+#                   }
+#                 ]
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "jeVDBjnNEeaetxLgjw7H8Q@0",
+#             "question": {
+#               "type": "singleNumeric"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nConsider the following two sentences.\n</text><list bulletType=\"bullets\"><li><text>Sentence 1: The quick brown fox jumps over the lazy dog.\n</text></li><li><text>Sentence 2: A quick brown dog outpaces a quick fox.\n</text></li></list><text>\n\nCompute the Euclidean distance using word counts. Round your answer to 3 decimal places.</text><text>Note. To compute word counts, turn all words into lower case and strip all punctuation, so that \"The\" and \"the\" are counted as the same token.</text></co-content>"
+#                   }
+#                 }
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "-tI-EjnNEeaPCw5NUSdt1w@0",
+#             "question": {
+#               "type": "singleNumeric"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>Refer back to the two sentences given in Question 2 to answer the following:</text><text>Recall that we can use cosine similarity to define a distance.  We call that distance cosine distance. </text><text>Compute the <strong>cosine distance</strong> using word counts. Round your answer to 3 decimal places.\n</text><text>Note: To compute word counts, turn all words into lower case and strip all punctuation, so that \"The\" and \"the\" are counted as the same token.</text><text>Hint. Recall that we can use cosine similarity to define a distance.  We call that distance cosine distance.</text></co-content>"
+#                   }
+#                 }
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "LGECRDnOEeaetxLgjw7H8Q@0",
+#             "question": {
+#               "type": "mcq"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>(True/False) For positive features, cosine similarity is always between 0 and 1.</text></co-content>"
+#                   }
+#                 },
+#                 "options": [
+#                   {
+#                     "id": "0.838238929639803",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>True</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.9654190569725087",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>False</text></co-content>"
+#                       }
+#                     }
+#                   }
+#                 ]
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "N62eSDnOEea5PAq35BZMoQ@0",
+#             "question": {
+#               "type": "mcq"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nUsing the formula for TF-IDF presented in the lecture, complete the following sentence:</text><text>A word is assigned a zero TF-IDF weight when it appears in ____ documents. (N: number of documents in the corpus)</text></co-content>"
+#                   }
+#                 },
+#                 "options": [
+#                   {
+#                     "id": "0.10877084920366831",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>N - 1</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.29922629273211787",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>N/2</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.69796593807345",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>N</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.6731572688278926",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>0.1*N</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.8467992755507772",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>100</text></co-content>"
+#                       }
+#                     }
+#                   }
+#                 ]
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "TuHdkjnOEeaPCw5NUSdt1w@0",
+#             "question": {
+#               "type": "mcq"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nWhich of the following does <strong>not </strong>describe the word count document representation?</text></co-content>"
+#                   }
+#                 },
+#                 "options": [
+#                   {
+#                     "id": "0.3821039264467949",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>Ignores the order of the words</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.3470767421220087",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>Assigns a high score to a frequently occurring word</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.3341840649172314",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>Penalizes words that appear in every document</text></co-content>"
+#                       }
+#                     }
+#                   }
+#                 ]
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           }
+#         ],
+#         "evaluation": null
+#       }
+#     }
+#   ],
+#   "paging": null,
+#   "linked": {
+#     "gradingAttempts.v1": []
+#   }
+# }
+#
+# Request payload:
+# {"name":"getState","argument":[]}
+POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS_GET_STATE = 'https://www.coursera.org/api/onDemandExamSessions.v1/{session_id}/actions?includes=gradingAttempts'
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # define a per-user cache folder

--- a/coursera/define.py
+++ b/coursera/define.py
@@ -37,7 +37,14 @@ OPENCOURSE_LIST_COURSES = 'https://www.coursera.org/api/courses.v1?q=watchlist&s
 # https://www.coursera.org/api/memberships.v1?fields=courseId,enrolledTimestamp,grade,id,lastAccessedTimestamp,onDemandSessionMembershipIds,onDemandSessionMemberships,role,v1SessionId,vc,vcMembershipId,courses.v1(courseStatus,display,partnerIds,photoUrl,specializations,startDate,v1Details,v2Details),partners.v1(homeLink,name),v1Details.v1(sessionIds),v1Sessions.v1(active,certificatesReleased,dbEndDate,durationString,hasSigTrack,startDay,startMonth,startYear),v2Details.v1(onDemandSessions,plannedLaunchDate,sessionsEnabledAt),specializations.v1(logo,name,partnerIds,shortName)&includes=courseId,onDemandSessionMemberships,vcMembershipId,courses.v1(partnerIds,specializations,v1Details,v2Details),v1Details.v1(sessionIds),v2Details.v1(onDemandSessions),specializations.v1(partnerIds)&q=me&showHidden=true&filter=current,preEnrolled
 # Sample reply:
 # {
-#     "elements": [],
+#     "elements": [
+#         {
+#             id: "4958~bVgqTevEEeWvGQrWsIkLlw",
+#             userId: 4958,
+#             courseId: "bVgqTevEEeWvGQrWsIkLlw",
+#             role: "LEARNER"
+#         },
+#     ],
 #     "paging": null,
 #     "linked": {
 #         "courses.v1": [
@@ -50,7 +57,7 @@ OPENCOURSE_LIST_COURSES = 'https://www.coursera.org/api/courses.v1?q=watchlist&s
 #         ]
 #     }
 # }
-OPENCOURSE_MEMBERSIPS = 'https://www.coursera.org/api/memberships.v1?includes=courseId,courses.v1&q=me&showHidden=true&filter=current,preEnrolled'
+OPENCOURSE_MEMBERSHIPS = 'https://www.coursera.org/api/memberships.v1?includes=courseId,courses.v1&q=me&showHidden=true&filter=current,preEnrolled'
 OPENCOURSE_CONTENT_URL = 'https://www.coursera.org/api/opencourse.v1/course/{class_name}?showLockedItems=true'
 OPENCOURSE_VIDEO_URL = 'https://www.coursera.org/api/opencourse.v1/video/{video_id}'
 OPENCOURSE_SUPPLEMENT_URL = 'https://www.coursera.org/api/onDemandSupplements.v1/'\
@@ -169,6 +176,253 @@ ABOUT_URL = ('https://api.coursera.org/api/catalog.v1/courses?'
 AUTH_REDIRECT_URL = ('https://class.coursera.org/{class_name}'
                      '/auth/auth_redirector?type=login&subtype=normal')
 
+#POST_OPENCOURSE_API_QUIZ_SESSION = 'https://www.coursera.org/api/opencourse.v1/user/4958/course/text-mining/item/7OQHc/quiz/session'
+# Sample response:
+#
+# {
+#   "contentResponseBody": {
+#     "session": {
+#       "id": "opencourse~bVgqTevEEeWvGQrWsIkLlw:4958:BiNDdOvPEeWAkwqbKEEh3w@13:1468773901987@1",
+#       "open": true
+#     }
+#   },
+#   "itemProgress": {
+#     "contentVersionedId": "BiNDdOvPEeWAkwqbKEEh3w@13",
+#     "timestamp": 1468774458435,
+#     "progressState": "Started"
+#   }
+# }
+POST_OPENCOURSE_API_QUIZ_SESSION = 'https://www.coursera.org/api/opencourse.v1/user/{user_id}/course/{class_name}/item/{quiz_id}/quiz/session'
+
+#POST_OPENCOURSE_API_QUIZ_SESSION_GET_STATE = 'https://www.coursera.org/api/opencourse.v1/user/4958/course/text-mining/item/7OQHc/quiz/session/opencourse~bVgqTevEEeWvGQrWsIkLlw:4958:BiNDdOvPEeWAkwqbKEEh3w@13:1468773901987@1/action/getState?autoEnroll=false'
+# Sample response:
+#
+# {
+#   "contentResponseBody": {
+#     "return": {
+#       "questions": [
+#         {
+#           "id": "89424f6873744b5c0b92da2936327bb4",
+#           "question": {
+#             "type": "mcq"
+#           },
+#           "variant": {
+#             "definition": {
+#               "prompt": {
+#                 "typeName": "cml",
+#                 "definition": {
+#                   "dtdId": "assess/1",
+#                   "value": "<co-content><text hasMath=\"true\">You are given a unigram language model $$\\theta$$ distributed over a vocabulary set $$V$$ composed of <strong>only</strong> 4 words: “the”, “machine”, “learning”, and “data”. The distribution of $$\\theta$$ is given in the table below:</text><table rows=\"5\" columns=\"2\"><tr><th><text>$$w$$</text></th><th><text>$$P(w|\\theta)$$</text></th></tr><tr><td><text>machine</text></td><td><text>0.1</text></td></tr><tr><td><text>learning</text></td><td><text>0.2</text></td></tr><tr><td><text>data</text></td><td><text>0.3</text></td></tr><tr><td><text>the</text></td><td><text>0.4</text></td></tr></table><text hasMath=\"true\"> $$P(\\text{“machine learning”}|\\theta) = $$</text></co-content>"
+#                 }
+#               },
+#               "options": [
+#                 {
+#                   "id": "717bd78dec2b817bed4b2d6096cbc9fc",
+#                   "display": {
+#                     "typeName": "cml",
+#                     "definition": {
+#                       "dtdId": "assess/1",
+#                       "value": "<co-content><text>0.004</text></co-content>"
+#                     }
+#                   }
+#                 },
+#                 {
+#                   "id": "a06c614cbb15b4e54212296b16fc4e62",
+#                   "display": {
+#                     "typeName": "cml",
+#                     "definition": {
+#                       "dtdId": "assess/1",
+#                       "value": "<co-content><text>0.2</text></co-content>"
+#                     }
+#                   }
+#                 },
+#                 {
+#                   "id": "029fe0fee932d6ad260f292dd05dc5c9",
+#                   "display": {
+#                     "typeName": "cml",
+#                     "definition": {
+#                       "dtdId": "assess/1",
+#                       "value": "<co-content><text>0.3</text></co-content>"
+#                     }
+#                   }
+#                 },
+#                 {
+#                   "id": "b6af6403d4ddde3b1e58599c12b6397a",
+#                   "display": {
+#                     "typeName": "cml",
+#                     "definition": {
+#                       "dtdId": "assess/1",
+#                       "value": "<co-content><text>0.02</text></co-content>"
+#                     }
+#                   }
+#                 }
+#               ]
+#             },
+#             "detailLevel": "Full"
+#           },
+#           "weightedScoring": {
+#             "maxScore": 1
+#           },
+#           "isSubmitAllowed": true
+#         }
+#       ],
+#       "evaluation": null
+#     }
+#   },
+#   "itemProgress": {
+#     "contentVersionedId": "BiNDdOvPEeWAkwqbKEEh3w@13",
+#     "timestamp": 1468774458894,
+#     "progressState": "Started"
+#   }
+# }
+#
+POST_OPENCOURSE_API_QUIZ_SESSION_GET_STATE = 'https://www.coursera.org/api/opencourse.v1/user/{user_id}/course/{class_name}/item/{quiz_id}/quiz/session/{session_id}/action/getState?autoEnroll=false'
+
+#POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS = 'https://www.coursera.org/api/onDemandExamSessions.v1/-N44X0IJEeWpogr5ZO8qxQ~YV0W4~10!~1467462079068/actions?includes=gradingAttempts'
+# Sample response:
+#
+# {
+#   "elements": [
+#     {
+#       "id": 0,
+#       "result": {
+#         "questions": [
+#           {
+#             "id": "8uUpMzm_EeaetxLgjw7H8Q@0",
+#             "question": {
+#               "type": "mcq"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nSuppose you’d like to perform nearest neighbor search from the following set of houses:</text><table rows=\"5\" columns=\"4\"><tr><td><text>\n\n\n\n\n\n</text></td><td><text>\n\n\nPrice (USD)</text></td><td><text>\n\n\nNumber of rooms</text></td><td><text>\n\n\nLot size (sq. ft.)</text></td></tr><tr><td><text>\n\n\nHouse 1</text></td><td><text>\n\n\n500000</text></td><td><text>\n\n\n3</text></td><td><text>\n\n\n1840</text></td></tr><tr><td><text>\n\n\nHouse 2</text></td><td><text>\n\n\n350000</text></td><td><text>\n\n\n2</text></td><td><text>\n\n\n1600</text></td></tr><tr><td><text>House 3</text></td><td><text>\n\n600000</text></td><td><text>\n\n4</text></td><td><text>\n\n2000</text></td></tr><tr><td><text>House 4</text></td><td><text>\n400000</text></td><td><text>\n2</text></td><td><text>\n1900</text></td></tr></table><text>\n\nSince the features come in wildly different scales, you decide to use scaled Euclidean distances. Choose the set of weights a_i (as presented in the video lecture) that properly incorporates the relative amount of variation of the feature.</text><text>Note: </text><code language=\"plain_text\">a_price = weight assigned to price (USD)\na_room  = weight assigned to number of rooms\na_lot   = weight assigned to lot size (sq.ft.)</code></co-content>"
+#                   }
+#                 },
+#                 "options": [
+#                   {
+#                     "id": "0.9109180361318947",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1, a_room = 1, a_lot = 1</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.11974743029080992",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1, a_room = 1, a_lot = 1e-6</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.8214165539451299",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e-10, a_room = 1, a_lot = 1e-6</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.6784789645868041",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e-5, a_room = 1, a_lot = 1e-3</text></co-content>"
+#                       }
+#                     }
+#                   },
+#                   {
+#                     "id": "0.9664001374497642",
+#                     "display": {
+#                       "typeName": "cml",
+#                       "definition": {
+#                         "dtdId": "assess/1",
+#                         "value": "<co-content><text>a_price = 1e5, a_room = 1, a_lot = 1e3</text></co-content>"
+#                       }
+#                     }
+#                   }
+#                 ]
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "jeVDBjnNEeaetxLgjw7H8Q@0",
+#             "question": {
+#               "type": "singleNumeric"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>\n\nConsider the following two sentences.\n</text><list bulletType=\"bullets\"><li><text>Sentence 1: The quick brown fox jumps over the lazy dog.\n</text></li><li><text>Sentence 2: A quick brown dog outpaces a quick fox.\n</text></li></list><text>\n\nCompute the Euclidean distance using word counts. Round your answer to 3 decimal places.</text><text>Note. To compute word counts, turn all words into lower case and strip all punctuation, so that \"The\" and \"the\" are counted as the same token.</text></co-content>"
+#                   }
+#                 }
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           },
+#           {
+#             "id": "-tI-EjnNEeaPCw5NUSdt1w@0",
+#             "question": {
+#               "type": "singleNumeric"
+#             },
+#             "variant": {
+#               "definition": {
+#                 "prompt": {
+#                   "typeName": "cml",
+#                   "definition": {
+#                     "dtdId": "assess/1",
+#                     "value": "<co-content><text>Refer back to the two sentences given in Question 2 to answer the following:</text><text>Recall that we can use cosine similarity to define a distance.  We call that distance cosine distance. </text><text>Compute the <strong>cosine distance</strong> using word counts. Round your answer to 3 decimal places.\n</text><text>Note: To compute word counts, turn all words into lower case and strip all punctuation, so that \"The\" and \"the\" are counted as the same token.</text><text>Hint. Recall that we can use cosine similarity to define a distance.  We call that distance cosine distance.</text></co-content>"
+#                   }
+#                 }
+#               },
+#               "detailLevel": "Full"
+#             },
+#             "weightedScoring": {
+#               "maxScore": 1
+#             },
+#             "isSubmitAllowed": true
+#           }
+#         ],
+#         "evaluation": null
+#       }
+#     }
+#   ],
+#   "paging": null,
+#   "linked": {
+#     "gradingAttempts.v1": []
+#   }
+# }
+#
+# Request payload:
+# {"courseId":"-N44X0IJEeWpogr5ZO8qxQ","itemId":"YV0W4"}
+#
+#POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS = 'https://www.coursera.org/api/onDemandExamSessions.v1/-N44X0IJEeWpogr5ZO8qxQ~YV0W4~10!~1467462079068/actions?includes=gradingAttempts'
+
+POST_OPENCOURSE_ONDEMAND_EXAM_SESSIONS = 'https://www.coursera.org/api/onDemandExamSessions.v1'
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # define a per-user cache folder
 if os.name == "posix":  # pragma: no cover
@@ -200,6 +454,18 @@ TITLE_MAX_LENGTH = 200
 #: CSS that is usen to prettify instructions
 INSTRUCTIONS_HTML_INJECTION = '''
 <style>
+table th, table td {
+    border: 1px solid #e0e0e0;
+    padding: 5px 20px;
+    text-align: left;
+}
+th {
+    font-weight: bold;
+}
+td, th {
+    display: table-cell;
+    vertical-align: inherit;
+}
 img {
     height: auto;
     max-width: 100%;

--- a/coursera/define.py
+++ b/coursera/define.py
@@ -771,10 +771,18 @@ TITLE_MAX_LENGTH = 200
 #: CSS that is usen to prettify instructions
 INSTRUCTIONS_HTML_INJECTION = '''
 <style>
+body {
+    padding: 50px 85px 50px 85px;
+}
+
 table th, table td {
     border: 1px solid #e0e0e0;
     padding: 5px 20px;
     text-align: left;
+}
+input {
+    margin: 10px;
+}
 }
 th {
     font-weight: bold;

--- a/coursera/extractors.py
+++ b/coursera/extractors.py
@@ -44,12 +44,14 @@ class CourseraExtractor(PlatformExtractor):
 
     def get_modules(self, class_name,
                     reverse=False, unrestricted_filenames=False,
-                    subtitle_language='en', video_resolution=None):
+                    subtitle_language='en', video_resolution=None,
+                    download_quizzes=False):
 
         page = self._get_on_demand_syllabus(class_name)
         modules = self._parse_on_demand_syllabus(
             page, reverse, unrestricted_filenames,
-            subtitle_language, video_resolution)
+            subtitle_language, video_resolution,
+            download_quizzes)
         return modules
 
     def _get_on_demand_syllabus(self, class_name):
@@ -66,7 +68,8 @@ class CourseraExtractor(PlatformExtractor):
     def _parse_on_demand_syllabus(self, page, reverse=False,
                                   unrestricted_filenames=False,
                                   subtitle_language='en',
-                                  video_resolution=None):
+                                  video_resolution=None,
+                                  download_quizzes=False):
         """
         Parse a Coursera on-demand course listing/syllabus page.
         """
@@ -134,10 +137,12 @@ class CourseraExtractor(PlatformExtractor):
                         links = course.extract_links_from_programming(lecture['id'])
 
                     elif typename == 'quiz':
-                        links = course.extract_links_from_quiz(lecture['id'])
+                        if download_quizzes:
+                            links = course.extract_links_from_quiz(lecture['id'])
 
                     elif typename == 'exam':
-                        links = course.extract_links_from_exam(lecture['id'])
+                        if download_quizzes:
+                            links = course.extract_links_from_exam(lecture['id'])
 
                     if links:
                         lectures.append((lecture_slug, links))

--- a/coursera/extractors.py
+++ b/coursera/extractors.py
@@ -133,13 +133,10 @@ class CourseraExtractor(PlatformExtractor):
                     elif typename in ('gradedProgramming', 'ungradedProgramming'):
                         links = course.extract_links_from_programming(lecture['id'])
 
-                    elif typename in ('quiz'):
-                        print('EXTR, quiz')
+                    elif typename == 'quiz':
                         links = course.extract_links_from_quiz(lecture['id'])
 
-                    elif typename in ('exam'):
-                        print('EXTR, exam')
-                        # Unsupported yet
+                    elif typename == 'exam':
                         links = course.extract_links_from_exam(lecture['id'])
 
                     if links:

--- a/coursera/extractors.py
+++ b/coursera/extractors.py
@@ -80,6 +80,7 @@ class CourseraExtractor(PlatformExtractor):
         json_modules = dom['courseMaterial']['elements']
         course = CourseraOnDemand(session=self._session, course_id=dom['id'],
                                   unrestricted_filenames=unrestricted_filenames)
+        course.obtain_user_id()
         ondemand_material_items = OnDemandCourseMaterialItems.create(
             session=self._session, course_name=course_name)
 
@@ -114,6 +115,7 @@ class CourseraExtractor(PlatformExtractor):
 
                     logging.info('Processing lecture         %s (%s)',
                                  lecture_slug, typename)
+                    links = None
 
                     if typename == 'lecture':
                         lecture_video_id = lecture['content']['definition']['videoId']
@@ -123,20 +125,25 @@ class CourseraExtractor(PlatformExtractor):
                             lecture_video_id, subtitle_language,
                             video_resolution, assets)
 
-                        if links:
-                            lectures.append((lecture_slug, links))
-
                     elif typename == 'supplement':
-                        supplement_content = course.extract_links_from_supplement(
+                        links = course.extract_links_from_supplement(
                             lecture['id'])
-                        if supplement_content:
-                            lectures.append((lecture_slug, supplement_content))
 
                     elif typename in ('gradedProgramming', 'ungradedProgramming'):
                         supplement_content = course.extract_links_from_programming(
                             lecture['id'])
-                        if supplement_content:
-                            lectures.append((lecture_slug, supplement_content))
+
+                    elif typename in ('quiz'):
+                        print('EXTR, quiz')
+                        course.extract_links_from_quiz(lecture['id'])
+
+                    elif typename in ('exam'):
+                        print('EXTR, exam')
+                        # Unsupported yet
+                        # course.extract_links_from_exam(lecture['id'])
+
+                    if links:
+                        lectures.append((lecture_slug, links))
 
                 if lectures:
                     sections.append((section_slug, lectures))

--- a/coursera/extractors.py
+++ b/coursera/extractors.py
@@ -79,6 +79,7 @@ class CourseraExtractor(PlatformExtractor):
         modules = []
         json_modules = dom['courseMaterial']['elements']
         course = CourseraOnDemand(session=self._session, course_id=dom['id'],
+                                  course_name=course_name,
                                   unrestricted_filenames=unrestricted_filenames)
         course.obtain_user_id()
         ondemand_material_items = OnDemandCourseMaterialItems.create(
@@ -130,17 +131,16 @@ class CourseraExtractor(PlatformExtractor):
                             lecture['id'])
 
                     elif typename in ('gradedProgramming', 'ungradedProgramming'):
-                        supplement_content = course.extract_links_from_programming(
-                            lecture['id'])
+                        links = course.extract_links_from_programming(lecture['id'])
 
                     elif typename in ('quiz'):
                         print('EXTR, quiz')
-                        course.extract_links_from_quiz(lecture['id'])
+                        links = course.extract_links_from_quiz(lecture['id'])
 
                     elif typename in ('exam'):
                         print('EXTR, exam')
                         # Unsupported yet
-                        # course.extract_links_from_exam(lecture['id'])
+                        links = course.extract_links_from_exam(lecture['id'])
 
                     if links:
                         lectures.append((lecture_slug, links))

--- a/coursera/network.py
+++ b/coursera/network.py
@@ -13,6 +13,24 @@ def get_reply(session, url, post=False, data=None, headers=None):
     """
     Download an HTML page using the requests session. Low-level function
     that allows for flexible request configuration.
+
+    @param session: Requests session.
+    @type session: requests.Session
+
+    @param url: URL pattern with optional keywords to format.
+    @type url: str
+
+    @param post: Flag that indicates whether POST request should be sent.
+    @type post: bool
+
+    @param data: Payload data that is sent with request (in request body).
+    @type data: object
+
+    @param headers: Additional headers to send with request.
+    @type headers: dict
+
+    @return: Requests response.
+    @rtype: requests.Response
     """
 
     request_headers = {} if headers is None else headers
@@ -34,9 +52,37 @@ def get_reply(session, url, post=False, data=None, headers=None):
     return reply
 
 
-def get_page(session, url, post=False, data=None, headers=None):
+def get_page(session,
+             url,
+             json=False,
+             post=False,
+             data=None,
+             headers=None,
+             **kwargs):
+    """
+    Download an HTML page using the requests session.
+
+    @param session: Requests session.
+    @type session: requests.Session
+
+    @param url: URL pattern with optional keywords to format.
+    @type url: str
+
+    @param post: Flag that indicates whether POST request should be sent.
+    @type post: bool
+
+    @param data: Payload data that is sent with request (in request body).
+    @type data: object
+
+    @param headers: Additional headers to send with request.
+    @type headers: dict
+
+    @return: Response body.
+    @rtype: str
+    """
+    url = url.format(**kwargs)
     reply = get_reply(session, url, post=post, data=data, headers=headers)
-    return reply.text
+    return reply.json() if json else reply.text
 
 
 def get_page_and_url(session, url):
@@ -44,59 +90,11 @@ def get_page_and_url(session, url):
     Download an HTML page using the requests session and return
     the final URL after following redirects.
     """
-
-    reply = session.get(url)
-
-    try:
-        reply.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        logging.error("Error %s getting page %s", e, url)
-        raise
-
+    reply = get_reply(session, url)
     return reply.text, reply.url
 
-
-def get_page_json(session, url, **kwargs):
-    """
-    Download page and parse it as JSON. This is a shorthand for common
-    operation.
-
-    @param session: Requests session.
-    @type session: requests.Session
-
-    @param url: URL pattern with optional keywords to format.
-    @type url: str
-
-    @param kwargs: Arguments to `url` pattern.
-
-    @return: Parsed JSON of the request page.
-    @rtype: dict
-    """
-    url = url.format(**kwargs)
-    page = get_page(session, url)
-    return json.loads(page)
 
 def post_page_and_reply(session, url, data=None, headers=None, **kwargs):
     url = url.format(**kwargs)
     reply = get_reply(session, url, post=True, data=data, headers=headers)
     return reply.text, reply
-
-def post_page_json(session, url, data=None, headers=None, **kwargs):
-    """
-    Download page and parse it as JSON. This is a shorthand for common
-    operation. Same as `get_page_json` but uses POST.
-
-    @param session: Requests session.
-    @type session: requests.Session
-
-    @param url: URL pattern with optional keywords to format.
-    @type url: str
-
-    @param kwargs: Arguments to `url` pattern.
-
-    @return: Parsed JSON of the request page.
-    @rtype: dict
-    """
-    page, _reply = post_page_and_reply(
-        session, url, data=data, headers=headers, **kwargs)
-    return json.loads(page)

--- a/coursera/network.py
+++ b/coursera/network.py
@@ -9,20 +9,34 @@ import logging
 import requests
 
 
-def get_page(session, url, post=False, data=None):
+def get_reply(session, url, post=False, data=None, headers=None):
     """
-    Download an HTML page using the requests session.
+    Download an HTML page using the requests session. Low-level function
+    that allows for flexible request configuration.
     """
 
-    r = session.post(url, data=data) if post else session.get(url)
+    request_headers = {} if headers is None else headers
+
+    request = requests.Request('POST' if post else 'GET',
+                               url,
+                               data=data,
+                               headers=request_headers)
+    prepared_request = session.prepare_request(request)
+
+    reply = session.send(prepared_request)
 
     try:
-        r.raise_for_status()
+        reply.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logging.error("Error %s getting page %s", e, url)
+        from ipdb import set_trace; set_trace()
         raise
 
-    return r.text
+    return reply
+
+def get_page(session, url, post=False, data=None, headers=None):
+    reply = get_reply(session, url, post=post, data=data, headers=headers)
+    return reply.text
 
 
 def get_page_and_url(session, url):
@@ -31,15 +45,15 @@ def get_page_and_url(session, url):
     the final URL after following redirects.
     """
 
-    r = session.get(url)
+    reply = session.get(url)
 
     try:
-        r.raise_for_status()
+        reply.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logging.error("Error %s getting page %s", e, url)
         raise
 
-    return r.text, r.url
+    return reply.text, reply.url
 
 
 def get_page_json(session, url, **kwargs):
@@ -62,7 +76,12 @@ def get_page_json(session, url, **kwargs):
     page = get_page(session, url)
     return json.loads(page)
 
-def post_page_json(session, url, data=None, **kwargs):
+def post_page_and_reply(session, url, data=None, headers=None, **kwargs):
+    url = url.format(**kwargs)
+    reply = get_reply(session, url, post=True, data=data, headers=headers)
+    return reply.text, reply
+
+def post_page_json(session, url, data=None, headers=None, **kwargs):
     """
     Download page and parse it as JSON. This is a shorthand for common
     operation. Same as `get_page_json` but uses POST.
@@ -78,6 +97,6 @@ def post_page_json(session, url, data=None, **kwargs):
     @return: Parsed JSON of the request page.
     @rtype: dict
     """
-    url = url.format(**kwargs)
-    page = get_page(session, url, post=True, data=data)
+    page, _reply = post_page_and_reply(
+        session, url, data=data, headers=headers, **kwargs)
     return json.loads(page)

--- a/coursera/network.py
+++ b/coursera/network.py
@@ -9,12 +9,12 @@ import logging
 import requests
 
 
-def get_page(session, url):
+def get_page(session, url, post=False, data=None):
     """
     Download an HTML page using the requests session.
     """
 
-    r = session.get(url)
+    r = session.post(url, data=data) if post else session.get(url)
 
     try:
         r.raise_for_status()
@@ -60,4 +60,24 @@ def get_page_json(session, url, **kwargs):
     """
     url = url.format(**kwargs)
     page = get_page(session, url)
+    return json.loads(page)
+
+def post_page_json(session, url, data=None, **kwargs):
+    """
+    Download page and parse it as JSON. This is a shorthand for common
+    operation. Same as `get_page_json` but uses POST.
+
+    @param session: Requests session.
+    @type session: requests.Session
+
+    @param url: URL pattern with optional keywords to format.
+    @type url: str
+
+    @param kwargs: Arguments to `url` pattern.
+
+    @return: Parsed JSON of the request page.
+    @rtype: dict
+    """
+    url = url.format(**kwargs)
+    page = get_page(session, url, post=True, data=data)
     return json.loads(page)

--- a/coursera/network.py
+++ b/coursera/network.py
@@ -47,6 +47,7 @@ def get_reply(session, url, post=False, data=None, headers=None):
         reply.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logging.error("Error %s getting page %s", e, url)
+        logging.error("The server replied: %s", reply.text)
         raise
 
     return reply

--- a/coursera/network.py
+++ b/coursera/network.py
@@ -29,10 +29,10 @@ def get_reply(session, url, post=False, data=None, headers=None):
         reply.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logging.error("Error %s getting page %s", e, url)
-        from ipdb import set_trace; set_trace()
         raise
 
     return reply
+
 
 def get_page(session, url, post=False, data=None, headers=None):
     reply = get_reply(session, url, post=post, data=data, headers=headers)

--- a/coursera/test/fixtures/json/asset-retriever/assets-reply.json
+++ b/coursera/test/fixtures/json/asset-retriever/assets-reply.json
@@ -1,29 +1,11 @@
 {
   "elements": [
     {
-      "id": "bYHvf8YwEeWFNA5XwZEiOw",
-      "name": "M114.mp3",
-      "typeName": "audio",
-      "url": {
-        "url": "url1",
-        "expires": 1469664000000
-      }
-    },
-    {
       "id": "VcmGXShKEea4ehL5RXz3EQ",
       "name": "09_graph_decomposition_starter_files_1.zip",
       "typeName": "generic",
       "url": {
         "url": "url2",
-        "expires": 1469664000000
-      }
-    },
-    {
-      "id": "bX9X18YwEeW7AxLLCrgDQQ",
-      "name": "M113.mp3",
-      "typeName": "audio",
-      "url": {
-        "url": "url3",
         "expires": 1469664000000
       }
     },
@@ -37,38 +19,11 @@
       }
     },
     {
-      "id": "tZmigMYxEeWFNA5XwZEiOw",
-      "name": "M115.mp3",
-      "typeName": "audio",
-      "url": {
-        "url": "url5",
-        "expires": 1469664000000
-      }
-    },
-    {
-      "id": "bXCx18YwEeWicwr5JH8fgw",
-      "name": "M112.mp3",
-      "typeName": "audio",
-      "url": {
-        "url": "url6",
-        "expires": 1469664000000
-      }
-    },
-    {
       "id": "VceKeChKEeaOMw70NkE3iw",
       "name": "09_graph_decomposition_problems_1.pdf",
       "typeName": "pdf",
       "url": {
         "url": "url7",
-        "expires": 1469664000000
-      }
-    },
-    {
-      "id": "nVhIAj61EeaGyBLfiQeo_w",
-      "name": "Capture.PNG",
-      "typeName": "image",
-      "url": {
-        "url": "url8",
         "expires": 1469664000000
       }
     },

--- a/coursera/test/fixtures/json/asset-retriever/assets-reply.json
+++ b/coursera/test/fixtures/json/asset-retriever/assets-reply.json
@@ -62,6 +62,24 @@
         "url": "url7",
         "expires": 1469664000000
       }
+    },
+    {
+      "id": "nVhIAj61EeaGyBLfiQeo_w",
+      "name": "Capture.PNG",
+      "typeName": "image",
+      "url": {
+        "url": "url8",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "vdqUTz61Eea_CQ5dfWSAjQ",
+      "name": "Capture.PNG",
+      "typeName": "image",
+      "url": {
+        "url": "url9",
+        "expires": 1469664000000
+      }
     }
   ],
   "paging": null,

--- a/coursera/test/fixtures/json/asset-retriever/assets-reply.json
+++ b/coursera/test/fixtures/json/asset-retriever/assets-reply.json
@@ -1,0 +1,69 @@
+{
+  "elements": [
+    {
+      "id": "bYHvf8YwEeWFNA5XwZEiOw",
+      "name": "M114.mp3",
+      "typeName": "audio",
+      "url": {
+        "url": "url1",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "VcmGXShKEea4ehL5RXz3EQ",
+      "name": "09_graph_decomposition_starter_files_1.zip",
+      "typeName": "generic",
+      "url": {
+        "url": "url2",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "bX9X18YwEeW7AxLLCrgDQQ",
+      "name": "M113.mp3",
+      "typeName": "audio",
+      "url": {
+        "url": "url3",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "bWTK9sYwEeW7AxLLCrgDQQ",
+      "name": "M111.mp3",
+      "typeName": "audio",
+      "url": {
+        "url": "url4",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "tZmigMYxEeWFNA5XwZEiOw",
+      "name": "M115.mp3",
+      "typeName": "audio",
+      "url": {
+        "url": "url5",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "bXCx18YwEeWicwr5JH8fgw",
+      "name": "M112.mp3",
+      "typeName": "audio",
+      "url": {
+        "url": "url6",
+        "expires": 1469664000000
+      }
+    },
+    {
+      "id": "VceKeChKEeaOMw70NkE3iw",
+      "name": "09_graph_decomposition_problems_1.pdf",
+      "typeName": "pdf",
+      "url": {
+        "url": "url7",
+        "expires": 1469664000000
+      }
+    }
+  ],
+  "paging": null,
+  "linked": null
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/answer-text-replaced-with-span-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/answer-text-replaced-with-span-input.json
@@ -1,0 +1,33 @@
+{
+    "evaluation": null,
+    "questions": [ {
+        "id": "-5nCBDnPEeaPCw5NUSdt1w@0",
+        "variant": {
+            "detailLevel": "Full",
+            "definition": {
+                "prompt": {
+                    "typeName": "cml",
+                    "definition": {
+                        "dtdId": "assess/1",
+                        "value": "<co-content><text>Lorem ipsum</text></co-content>"
+                    }
+                },
+                "options": [ {
+                    "id": "0.1634510137510934",
+                    "display": {
+                        "typeName": "cml",
+                        "definition": {
+                            "dtdId": "assess/1",
+                            "value": "<co-content><text>Data point 1</text></co-content>"
+                        }
+                    }
+                }
+                ]
+            }
+        },
+        "question": {
+            "type": "textExactMatch"
+        }
+    }
+    ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/answer-text-replaced-with-span-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/answer-text-replaced-with-span-output.txt
@@ -1,0 +1,11 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<form>
+<label><input type="" name="0"><co-content>
+ <span>
+  Data point 1
+ </span>
+</co-content><br></label>
+</form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/empty-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/empty-input.json
@@ -1,0 +1,5 @@
+{
+  "evaluation": null,
+  "questions": [
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/multiple-questions-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/multiple-questions-input.json
@@ -1,0 +1,100 @@
+{
+    "questions": [
+        {
+            "id": "TajkZzNrEea7yAqn1iZwEQ@0",
+            "variant": {
+                "detailLevel": "Full",
+                "definition": {
+                    "prompt": {
+                        "typeName": "cml",
+                        "definition": {
+                            "dtdId": "assess/1",
+                            "value": "<co-content><text>Question 1</text></co-content>"
+                        }
+                    }
+                }
+            },
+            "question": {
+                "type": "textExactMatch"
+            }
+        },
+        {
+            "id": "-5nCBDnPEeaPCw5NUSdt1w@0",
+            "variant": {
+                "detailLevel": "Full",
+                "definition": {
+                    "prompt": {
+                        "typeName": "cml",
+                        "definition": {
+                            "dtdId": "assess/1",
+                            "value": "<co-content><text>Question 2</text></co-content>"
+                        }
+                    },
+                    "options": [
+                        {
+                            "id": "0.1634510137510934",
+                            "display": {
+                                "typeName": "cml",
+                                "definition": {
+                                    "dtdId": "assess/1",
+                                    "value": "<co-content><text>Data point 1</text></co-content>"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "question": {
+                "type": "checkbox"
+            }
+        },
+        {
+            "id": "8uUpMzm_EeaetxLgjw7H8Q@0",
+            "variant": {
+                "detailLevel": "Full",
+                "definition": {
+                    "prompt": {
+                        "typeName": "cml",
+                        "definition": {
+                            "dtdId": "assess/1",
+                            "value": "<co-content><text>Question 3</text></co-content>"
+                        }
+                    },
+                    "options": [
+                        {
+                            "id": "0.9109180361318947",
+                            "display": {
+                                "typeName": "cml",
+                                "definition": {
+                                    "dtdId": "assess/1",
+                                    "value": "<co-content><text>Data point 2</text></co-content>"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "question": {
+                "type": "mcq"
+            }
+        },
+        {
+            "id": "jeVDBjnNEeaetxLgjw7H8Q@0",
+            "variant": {
+                "detailLevel": "Full",
+                "definition": {
+                    "prompt": {
+                        "typeName": "cml",
+                        "definition": {
+                            "dtdId": "assess/1",
+                            "value": "<co-content><text>Question 4</text></co-content>"
+                        }
+                    }
+                }
+            },
+            "question": {
+                "type": "singleNumeric"
+            }
+        }
+    ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/multiple-questions-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/multiple-questions-output.txt
@@ -1,0 +1,28 @@
+<h3>Question 1</h3>
+<co-content><text>Question 1</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>
+<h3>Question 2</h3>
+<co-content><text>Question 2</text></co-content>
+<form>
+<label><input type="checkbox" name="1"><co-content>
+ <span>
+  Data point 1
+ </span>
+</co-content><br></label>
+</form>
+<hr>
+<h3>Question 3</h3>
+<co-content><text>Question 3</text></co-content>
+<form>
+<label><input type="radio" name="2"><co-content>
+ <span>
+  Data point 2
+ </span>
+</co-content><br></label>
+</form>
+<hr>
+<h3>Question 4</h3>
+<co-content><text>Question 4</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-checkbox-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-checkbox-input.json
@@ -1,0 +1,45 @@
+{
+  "evaluation": null,
+  "questions": [
+      {
+          "id": "-5nCBDnPEeaPCw5NUSdt1w@0",
+          "variant": {
+              "detailLevel": "Full",
+              "definition": {
+                  "prompt": {
+                      "typeName": "cml",
+                      "definition": {
+                          "dtdId": "assess/1",
+                          "value": "<co-content><text>Lorem ipsum</text></co-content>"
+                      }
+                  },
+                  "options": [
+                      {
+                          "id": "0.1634510137510934",
+                          "display": {
+                              "typeName": "cml",
+                              "definition": {
+                                  "dtdId": "assess/1",
+                                  "value": "<co-content><text>Data point 1</text></co-content>"
+                              }
+                          }
+                      },
+                      {
+                          "id": "0.5981811018467218",
+                          "display": {
+                              "typeName": "cml",
+                              "definition": {
+                                  "dtdId": "assess/1",
+                                  "value": "<co-content><text>Data point 2  </text></co-content>"
+                              }
+                          }
+                      }
+                  ]
+              }
+          },
+          "question": {
+              "type": "checkbox"
+          }
+     }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-checkbox-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-checkbox-output.txt
@@ -1,0 +1,15 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form>
+<label><input type="checkbox" name="0"><co-content>
+ <span>
+  Data point 1
+ </span>
+</co-content><br></label>
+<label><input type="checkbox" name="0"><co-content>
+ <span>
+  Data point 2
+ </span>
+</co-content><br></label>
+</form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-mathExpression-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-mathExpression-input.json
@@ -1,0 +1,27 @@
+{
+  "evaluation": null,
+  "questions": [
+      {
+          "id": "TajkZzNrEea7yAqn1iZwEQ@0",
+          "variant": {
+              "detailLevel": "Full",
+              "definition": {
+                  "prompt": {
+                      "typeName": "cml",
+                      "definition": {
+                          "dtdId": "assess/1",
+                          "value": "<co-content><text>Lorem ipsum</text></co-content>"
+                      }
+                  }
+              }
+          },
+          "weightedScoring": {
+              "maxScore": 1
+          },
+          "isSubmitAllowed": true,
+          "question": {
+              "type": "mathExpression"
+          }
+      }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-mathExpression-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-mathExpression-output.txt
@@ -1,0 +1,4 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-mcq-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-mcq-input.json
@@ -1,0 +1,44 @@
+{
+  "questions": [
+    {
+      "id": "8uUpMzm_EeaetxLgjw7H8Q@0",
+      "variant": {
+        "detailLevel": "Full",
+        "definition": {
+          "prompt": {
+            "typeName": "cml",
+            "definition": {
+              "dtdId": "assess/1",
+              "value": "<co-content><text>Lorem ipsum</text></co-content>"
+            }
+          },
+          "options": [
+            {
+              "id": "0.9109180361318947",
+              "display": {
+                "typeName": "cml",
+                "definition": {
+                  "dtdId": "assess/1",
+                  "value": "<co-content><text>Answer 1</text></co-content>"
+                }
+              }
+            },
+            {
+              "id": "0.11974743029080992",
+              "display": {
+                "typeName": "cml",
+                "definition": {
+                  "dtdId": "assess/1",
+                  "value": "<co-content><text>Answer 2</text></co-content>"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "question": {
+        "type": "mcq"
+      }
+    }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-mcq-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-mcq-output.txt
@@ -1,0 +1,15 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form>
+<label><input type="radio" name="0"><co-content>
+ <span>
+  Answer 1
+ </span>
+</co-content><br></label>
+<label><input type="radio" name="0"><co-content>
+ <span>
+  Answer 2
+ </span>
+</co-content><br></label>
+</form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-regex-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-regex-input.json
@@ -1,0 +1,27 @@
+{
+  "evaluation": null,
+  "questions": [
+      {
+          "id": "TajkZzNrEea7yAqn1iZwEQ@0",
+          "variant": {
+              "detailLevel": "Full",
+              "definition": {
+                  "prompt": {
+                      "typeName": "cml",
+                      "definition": {
+                          "dtdId": "assess/1",
+                          "value": "<co-content><text>Lorem ipsum</text></co-content>"
+                      }
+                  }
+              }
+          },
+          "weightedScoring": {
+              "maxScore": 1
+          },
+          "isSubmitAllowed": true,
+          "question": {
+              "type": "regex"
+          }
+      }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-regex-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-regex-output.txt
@@ -1,0 +1,4 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-singleNumeric-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-singleNumeric-input.json
@@ -1,0 +1,27 @@
+{
+  "evaluation": null,
+  "questions": [
+    {
+      "id": "jeVDBjnNEeaetxLgjw7H8Q@0",
+      "variant": {
+        "detailLevel": "Full",
+        "definition": {
+          "prompt": {
+            "typeName": "cml",
+            "definition": {
+              "dtdId": "assess/1",
+              "value": "<co-content><text>Lorem ipsum</text></co-content>"
+            }
+          }
+        }
+      },
+      "weightedScoring": {
+        "maxScore": 1
+      },
+      "isSubmitAllowed": true,
+      "question": {
+        "type": "singleNumeric"
+      }
+    }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-singleNumeric-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-singleNumeric-output.txt
@@ -1,0 +1,4 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-textExactMatch-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-textExactMatch-input.json
@@ -1,0 +1,27 @@
+{
+  "evaluation": null,
+  "questions": [
+      {
+          "id": "TajkZzNrEea7yAqn1iZwEQ@0",
+          "variant": {
+              "detailLevel": "Full",
+              "definition": {
+                  "prompt": {
+                      "typeName": "cml",
+                      "definition": {
+                          "dtdId": "assess/1",
+                          "value": "<co-content><text>Lorem ipsum</text></co-content>"
+                      }
+                  }
+              }
+          },
+          "weightedScoring": {
+              "maxScore": 1
+          },
+          "isSubmitAllowed": true,
+          "question": {
+              "type": "textExactMatch"
+          }
+      }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-textExactMatch-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-textExactMatch-output.txt
@@ -1,0 +1,4 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<form><label>Enter answer here:<input type="text" name=""><br></label></form>
+<hr>

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-unknown-input.json
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-unknown-input.json
@@ -1,0 +1,27 @@
+{
+  "evaluation": null,
+  "questions": [
+    {
+      "id": "jeVDBjnNEeaetxLgjw7H8Q@0",
+      "variant": {
+        "detailLevel": "Full",
+        "definition": {
+          "prompt": {
+            "typeName": "cml",
+            "definition": {
+              "dtdId": "assess/1",
+              "value": "<co-content><text>Lorem ipsum</text></co-content>"
+            }
+          }
+        }
+      },
+      "weightedScoring": {
+        "maxScore": 1
+      },
+      "isSubmitAllowed": true,
+      "question": {
+        "type": "unknown"
+      }
+    }
+  ]
+}

--- a/coursera/test/fixtures/json/quiz-to-markup/question-type-unknown-output.txt
+++ b/coursera/test/fixtures/json/quiz-to-markup/question-type-unknown-output.txt
@@ -1,0 +1,3 @@
+<h3>Question 1</h3>
+<co-content><text>Lorem ipsum</text></co-content>
+<hr>

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -132,6 +132,30 @@ def test_list_courses(get_page_json, course):
     output = course.list_courses()
     assert expected_output == output
 
+
+@pytest.mark.parametrize(
+    "input_filename,output_filename", [
+        ('empty-input.json', 'empty-output.txt'),
+        ('answer-text-replaced-with-span-input.json', 'answer-text-replaced-with-span-output.txt'),
+        ('question-type-textExactMatch-input.json', 'question-type-textExactMatch-output.txt'),
+        ('question-type-checkbox-input.json', 'question-type-checkbox-output.txt'),
+        ('question-type-mcq-input.json', 'question-type-mcq-output.txt'),
+        ('question-type-singleNumeric-input.json', 'question-type-singleNumeric-output.txt'),
+        ('question-type-unknown-input.json', 'question-type-unknown-output.txt'),
+        ('multiple-questions-input.json', 'multiple-questions-output.txt'),
+    ]
+)
+def test_quiz_exam_to_markup_converter(input_filename, output_filename):
+    quiz_json = json.loads(slurp_fixture('json/quiz-to-markup/%s' % input_filename))
+    expected_output = slurp_fixture('json/quiz-to-markup/%s' % output_filename).strip()
+
+    converter = api.QuizExamToMarkupConverter(session=None)
+    actual_output = converter(quiz_json).strip()
+    # print('>%s<' % expected_output)
+    # print('>%s<' % actual_output)
+    assert actual_output == expected_output
+
+
 def test_quiz_converter():
     pytest.skip()
     quiz_to_markup = api.QuizExamToMarkupConverter(session=None)

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -276,6 +276,38 @@ class TestMarkupToHTMLConverter:
         </co-content>\n
         """) + self.STYLE == output
 
+    @patch('coursera.api.AssetRetriever')
+    def test_replace_audios(self, mock_asset_retriever):
+        replies = {
+            'aWTK9sYwEeW7AxLLCrgDQQ': Mock(data=b'a', content_type='audio/mpeg'),
+            'bWTK9sYwEeW7AxLLCrgDQQ': Mock(data=b'b', content_type='unknown')
+        }
+        mock_asset_retriever.__call__ = Mock(return_value=None)
+        mock_asset_retriever.__getitem__  = Mock(side_effect=replies.__getitem__)
+        self.markup_to_html._asset_retriever = mock_asset_retriever
+
+        output = self.markup_to_html("""
+        <co-content>
+            <asset id=\"aWTK9sYwEeW7AxLLCrgDQQ\" name=\"M111\" extension=\"mp3\" assetType=\"audio\"/>
+            <asset id=\"bWTK9sYwEeW7AxLLCrgDQQ\" name=\"M112\" extension=\"mp3\" assetType=\"unknown\"/>
+        </co-content>
+        """)
+
+        assert self._p("""
+        <meta charset="UTF-8"/>
+        <co-content>
+            <asset assettype="audio" extension="mp3" id="aWTK9sYwEeW7AxLLCrgDQQ" name="M111">
+            </asset>
+            <audio controls="">
+             Your browser does not support the audio element.
+             <source src="data:audio/mpeg;base64,YQ==" type="audio/mpeg">
+             </source>
+            </audio>
+            <asset assettype="unknown" extension="mp3" id="bWTK9sYwEeW7AxLLCrgDQQ" name="M112">
+            </asset>
+        </co-content>\n
+        """) + self.STYLE == output
+
 
 def test_quiz_converter():
     pytest.skip()
@@ -290,7 +322,7 @@ def test_quiz_converter():
         file.write(result)
 
 def test_quiz_converter_all():
-    pytest.skip()
+    # pytest.skip()
     import os
 
     from coursera.coursera_dl import get_session
@@ -302,7 +334,7 @@ def test_quiz_converter_all():
     markup_to_html = api.MarkupToHTMLConverter(session=session)
 
     path = 'quiz_json'
-    for filename in os.listdir(path):
+    for filename in ['quiz-audio.json']: #os.listdir(path):
     # for filename in ['all_question_types.json']:
         # if 'YV0W4' not in filename:
         #     continue

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -171,7 +171,9 @@ class TestMarkupToHTMLConverter:
 
     def test_empty(self):
         output = self.markup_to_html("")
-        assert self.STYLE == output
+        assert self._p("""
+        <meta charset="UTF-8"/>
+        """) + self.STYLE == output
 
     def test_replace_text_tag(self):
         output = self.markup_to_html("""
@@ -185,6 +187,7 @@ class TestMarkupToHTMLConverter:
         </co-content>
         """)
         assert self._p("""
+        <meta charset="UTF-8"/>
         <co-content>
         <p>
             Test<p>Nested</p>
@@ -207,6 +210,7 @@ class TestMarkupToHTMLConverter:
         </co-content>
         """)
         assert self._p("""
+        <meta charset="UTF-8"/>
         <co-content>
             <h1 level="1">Text</h1>
             <h2 level="2">Text</h2>
@@ -225,6 +229,7 @@ class TestMarkupToHTMLConverter:
         </co-content>
         """)
         assert self._p("""
+        <meta charset="UTF-8"/>
         <co-content>
             <pre>Text</pre>
             <pre>Text</pre>
@@ -239,6 +244,7 @@ class TestMarkupToHTMLConverter:
         </co-content>
         """)
         assert self._p("""
+        <meta charset="UTF-8"/>
         <co-content>
             <ol bullettype="numbers">Text</ol>
             <ul bullettype="bullets">Text</ul>
@@ -267,6 +273,7 @@ class TestMarkupToHTMLConverter:
         """)
 
         assert self._p("""
+        <meta charset="UTF-8"/>
         <co-content>
             <p></p>
             <img alt="" assetid="nVhIAj61EeaGyBLfiQeo_w" src="data:image/png;base64,YQ=="/>
@@ -322,7 +329,7 @@ def test_quiz_converter():
         file.write(result)
 
 def test_quiz_converter_all():
-    # pytest.skip()
+    pytest.skip()
     import os
 
     from coursera.coursera_dl import get_session

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -356,7 +356,8 @@ def test_asset_retriever(get_reply, get_page_json):
     assert expected_output == actual_output
 
 
-def old_test_asset_retriever():
+def test_debug_asset_retriever():
+    pytest.skip()
     asset_ids = ['bWTK9sYwEeW7AxLLCrgDQQ',
                  'bXCx18YwEeWicwr5JH8fgw',
                  'bX9X18YwEeW7AxLLCrgDQQ',

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -245,6 +245,23 @@ class TestMarkupToHTMLConverter:
         </co-content>\n
         """) + self.STYLE == output
 
+    def test_replace_images(self):
+        output = self.markup_to_html("""
+        "<co-content>
+            <text>\n\n</text>
+            <img assetId=\"nVhIAj61EeaGyBLfiQeo_w\" alt=\"\"/>
+            <text>\n\n</text>
+            <img assetId=\"vdqUTz61Eea_CQ5dfWSAjQ\" alt=\"\"/>
+            <text>\n\n</text>
+        </co-content>"
+        """)
+        assert self._p("""
+        <co-content>
+            <ol bullettype="numbers">Text</ol>
+            <ul bullettype="bullets">Text</ul>
+        </co-content>\n
+        """) + self.STYLE == output
+
 
 def test_quiz_converter():
     pytest.skip()
@@ -304,7 +321,7 @@ def create_session():
 def test_asset_retriever(get_reply, get_page_json):
     reply = json.loads(slurp_fixture('json/asset-retriever/assets-reply.json'))
     get_page_json.side_effect = [reply]
-    get_reply.side_effect = [Mock(status_code=200, content='<...>')] * 7
+    get_reply.side_effect = [Mock(status_code=200, content='<...>')] * 9
 
     asset_ids = ['bWTK9sYwEeW7AxLLCrgDQQ',
                  'bXCx18YwEeWicwr5JH8fgw',
@@ -312,7 +329,9 @@ def test_asset_retriever(get_reply, get_page_json):
                  'bYHvf8YwEeWFNA5XwZEiOw',
                  'tZmigMYxEeWFNA5XwZEiOw',
                  'VceKeChKEeaOMw70NkE3iw',
-                 'VcmGXShKEea4ehL5RXz3EQ']
+                 'VcmGXShKEea4ehL5RXz3EQ',
+                 'nVhIAj61EeaGyBLfiQeo_w',
+                 'vdqUTz61Eea_CQ5dfWSAjQ']
 
     expected_output = [
         api.Asset(id="bWTK9sYwEeW7AxLLCrgDQQ", name="M111.mp3", type_name="audio", url="url4", data="<...>"),
@@ -321,10 +340,12 @@ def test_asset_retriever(get_reply, get_page_json):
         api.Asset(id="bYHvf8YwEeWFNA5XwZEiOw", name="M114.mp3", type_name="audio", url="url1", data="<...>"),
         api.Asset(id="tZmigMYxEeWFNA5XwZEiOw", name="M115.mp3", type_name="audio", url="url5", data="<...>"),
         api.Asset(id="VceKeChKEeaOMw70NkE3iw", name="09_graph_decomposition_problems_1.pdf", type_name="pdf", url="url7", data="<...>"),
-        api.Asset(id="VcmGXShKEea4ehL5RXz3EQ", name="09_graph_decomposition_starter_files_1.zip", type_name="generic", url="url2", data="<...>")
+        api.Asset(id="VcmGXShKEea4ehL5RXz3EQ", name="09_graph_decomposition_starter_files_1.zip", type_name="generic", url="url2", data="<...>"),
+        api.Asset(id="nVhIAj61EeaGyBLfiQeo_w", name="Capture.PNG", type_name="image", url="url8", data="<...>"),
+        api.Asset(id="vdqUTz61Eea_CQ5dfWSAjQ", name="Capture.PNG", type_name="image", url="url9", data="<...>"),
     ]
 
-    retriever = api.AssetRetrievier(session=None)
+    retriever = api.AssetRetriever(session=None)
     actual_output = retriever(asset_ids)
 
     assert expected_output == actual_output
@@ -343,7 +364,7 @@ def old_test_asset_retriever():
 
     print('session')
     session = create_session()
-    retriever = api.AssetRetrievier(session)
+    retriever = api.AssetRetriever(session)
     #assets = retriever.get(asset_ids)
     assets = retriever(more)
 

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -5,7 +5,7 @@ from os.path import expanduser
 import json
 
 import pytest
-from mock import patch
+from mock import patch, Mock
 
 from coursera import api
 from coursera import define
@@ -298,7 +298,39 @@ def create_session():
     login(session, username, password)
     return session
 
-def test_asset_retriever():
+
+@patch('coursera.api.get_page_json')
+@patch('coursera.api.get_reply')
+def test_asset_retriever(get_reply, get_page_json):
+    reply = json.loads(slurp_fixture('json/asset-retriever/assets-reply.json'))
+    get_page_json.side_effect = [reply]
+    get_reply.side_effect = [Mock(status_code=200, content='<...>')] * 7
+
+    asset_ids = ['bWTK9sYwEeW7AxLLCrgDQQ',
+                 'bXCx18YwEeWicwr5JH8fgw',
+                 'bX9X18YwEeW7AxLLCrgDQQ',
+                 'bYHvf8YwEeWFNA5XwZEiOw',
+                 'tZmigMYxEeWFNA5XwZEiOw',
+                 'VceKeChKEeaOMw70NkE3iw',
+                 'VcmGXShKEea4ehL5RXz3EQ']
+
+    expected_output = [
+        api.Asset(id="bWTK9sYwEeW7AxLLCrgDQQ", name="M111.mp3", type_name="audio", url="url4", data="<...>"),
+        api.Asset(id="bXCx18YwEeWicwr5JH8fgw", name="M112.mp3", type_name="audio", url="url6", data="<...>"),
+        api.Asset(id="bX9X18YwEeW7AxLLCrgDQQ", name="M113.mp3", type_name="audio", url="url3", data="<...>"),
+        api.Asset(id="bYHvf8YwEeWFNA5XwZEiOw", name="M114.mp3", type_name="audio", url="url1", data="<...>"),
+        api.Asset(id="tZmigMYxEeWFNA5XwZEiOw", name="M115.mp3", type_name="audio", url="url5", data="<...>"),
+        api.Asset(id="VceKeChKEeaOMw70NkE3iw", name="09_graph_decomposition_problems_1.pdf", type_name="pdf", url="url7", data="<...>"),
+        api.Asset(id="VcmGXShKEea4ehL5RXz3EQ", name="09_graph_decomposition_starter_files_1.zip", type_name="generic", url="url2", data="<...>")
+    ]
+
+    retriever = api.AssetRetrievier(session=None)
+    actual_output = retriever(asset_ids)
+
+    assert expected_output == actual_output
+
+
+def old_test_asset_retriever():
     asset_ids = ['bWTK9sYwEeW7AxLLCrgDQQ',
                  'bXCx18YwEeWicwr5JH8fgw',
                  'bX9X18YwEeW7AxLLCrgDQQ',
@@ -315,6 +347,4 @@ def test_asset_retriever():
     #assets = retriever.get(asset_ids)
     assets = retriever(more)
 
-    print(assets)
-    from ipdb import set_trace; set_trace()
     print(assets)

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -141,6 +141,8 @@ def test_list_courses(get_page, course):
         ('empty-input.json', 'empty-output.txt'),
         ('answer-text-replaced-with-span-input.json', 'answer-text-replaced-with-span-output.txt'),
         ('question-type-textExactMatch-input.json', 'question-type-textExactMatch-output.txt'),
+        ('question-type-regex-input.json', 'question-type-regex-output.txt'),
+        ('question-type-mathExpression-input.json', 'question-type-mathExpression-output.txt'),
         ('question-type-checkbox-input.json', 'question-type-checkbox-output.txt'),
         ('question-type-mcq-input.json', 'question-type-mcq-output.txt'),
         ('question-type-singleNumeric-input.json', 'question-type-singleNumeric-output.txt'),

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -13,7 +13,8 @@ from coursera.test.utils import slurp_fixture
 
 @pytest.fixture
 def course():
-    course = api.CourseraOnDemand(session=None, course_id='0')
+    course = api.CourseraOnDemand(
+        session=None, course_id='0', course_name='test_course')
     return course
 
 
@@ -132,6 +133,7 @@ def test_list_courses(get_page_json, course):
     assert expected_output == output
 
 def test_quiz_converter():
+    pytest.skip()
     quiz_to_markup = api.QuizExamToMarkupConverter(session=None)
     markup_to_html = api.MarkupToHTMLConverter(session=session)
 
@@ -143,6 +145,7 @@ def test_quiz_converter():
         file.write(result)
 
 def test_quiz_converter_all():
+    pytest.skip()
     import os
 
     from coursera.coursera_dl import get_session

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -21,19 +21,19 @@ def course():
     return course
 
 
-@patch('coursera.api.get_page_json')
-def test_ondemand_programming_supplement_no_instructions(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_ondemand_programming_supplement_no_instructions(get_page, course):
     no_instructions = slurp_fixture('json/supplement-programming-no-instructions.json')
-    get_page_json.return_value = json.loads(no_instructions)
+    get_page.return_value = json.loads(no_instructions)
 
     output = course.extract_links_from_programming('0')
     assert {} == output
 
 
-@patch('coursera.api.get_page_json')
-def test_ondemand_programming_supplement_empty_instructions(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_ondemand_programming_supplement_empty_instructions(get_page, course):
     empty_instructions = slurp_fixture('json/supplement-programming-empty-instructions.json')
-    get_page_json.return_value = json.loads(empty_instructions)
+    get_page.return_value = json.loads(empty_instructions)
     output = course.extract_links_from_programming('0')
 
     # Make sure that SOME html content has been extracted, but remove
@@ -45,12 +45,12 @@ def test_ondemand_programming_supplement_empty_instructions(get_page_json, cours
     assert {} == output
 
 
-@patch('coursera.api.get_page_json')
-def test_ondemand_programming_supplement_one_asset(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_ondemand_programming_supplement_one_asset(get_page, course):
     one_asset_tag = slurp_fixture('json/supplement-programming-one-asset.json')
     one_asset_url = slurp_fixture('json/asset-urls-one.json')
     asset_json = json.loads(one_asset_url)
-    get_page_json.side_effect = [json.loads(one_asset_tag),
+    get_page.side_effect = [json.loads(one_asset_tag),
                                  json.loads(one_asset_url)]
 
     expected_output = {'pdf': [(asset_json['elements'][0]['url'],
@@ -66,11 +66,11 @@ def test_ondemand_programming_supplement_one_asset(get_page_json, course):
     assert expected_output == output
 
 
-@patch('coursera.api.get_page_json')
-def test_ondemand_programming_supplement_three_assets(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_ondemand_programming_supplement_three_assets(get_page, course):
     three_assets_tag = slurp_fixture('json/supplement-programming-three-assets.json')
     three_assets_url = slurp_fixture('json/asset-urls-three.json')
-    get_page_json.side_effect = [json.loads(three_assets_tag),
+    get_page.side_effect = [json.loads(three_assets_tag),
                                  json.loads(three_assets_url)]
 
     expected_output = json.loads(slurp_fixture('json/supplement-three-assets-output.json'))
@@ -86,11 +86,11 @@ def test_ondemand_programming_supplement_three_assets(get_page_json, course):
     assert expected_output == output
 
 
-@patch('coursera.api.get_page_json')
-def test_extract_links_from_lecture_assets_typename_asset(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_extract_links_from_lecture_assets_typename_asset(get_page, course):
     open_course_assets_reply = slurp_fixture('json/supplement-open-course-assets-reply.json')
     api_assets_v1_reply = slurp_fixture('json/supplement-api-assets-v1-reply.json')
-    get_page_json.side_effect = [json.loads(open_course_assets_reply),
+    get_page.side_effect = [json.loads(open_course_assets_reply),
                                  json.loads(api_assets_v1_reply)]
 
     expected_output = json.loads(slurp_fixture('json/supplement-extract-links-from-lectures-output.json'))
@@ -100,13 +100,13 @@ def test_extract_links_from_lecture_assets_typename_asset(get_page_json, course)
     assert expected_output == output
 
 
-@patch('coursera.api.get_page_json')
-def test_extract_links_from_lecture_assets_typname_url_and_asset(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_extract_links_from_lecture_assets_typname_url_and_asset(get_page, course):
     """
     This test makes sure that _extract_links_from_lecture_assets grabs url
     links both from typename == 'asset' and == 'url'.
     """
-    get_page_json.side_effect = [
+    get_page.side_effect = [
         json.loads(slurp_fixture('json/supplement-open-course-assets-typename-url-reply-1.json')),
         json.loads(slurp_fixture('json/supplement-open-course-assets-typename-url-reply-2.json')),
         json.loads(slurp_fixture('json/supplement-open-course-assets-typename-url-reply-3.json')),
@@ -122,12 +122,12 @@ def test_extract_links_from_lecture_assets_typname_url_and_asset(get_page_json, 
     output = json.loads(json.dumps(output))
     assert expected_output == output
 
-@patch('coursera.api.get_page_json')
-def test_list_courses(get_page_json, course):
+@patch('coursera.api.get_page')
+def test_list_courses(get_page, course):
     """
     Test course listing method.
     """
-    get_page_json.side_effect = [
+    get_page.side_effect = [
         json.loads(slurp_fixture('json/list-courses-input.json'))
     ]
     expected_output = json.loads(slurp_fixture('json/list-courses-output.json'))
@@ -369,11 +369,11 @@ def create_session():
     return session
 
 
-@patch('coursera.api.get_page_json')
+@patch('coursera.api.get_page')
 @patch('coursera.api.get_reply')
-def test_asset_retriever(get_reply, get_page_json):
+def test_asset_retriever(get_reply, get_page):
     reply = json.loads(slurp_fixture('json/asset-retriever/assets-reply.json'))
-    get_page_json.side_effect = [reply]
+    get_page.side_effect = [reply]
     get_reply.side_effect = [Mock(status_code=200, content='<...>',
                                   headers=Mock(get=Mock(return_value='image/png')))] * 4
 

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -130,3 +130,12 @@ def test_list_courses(get_page_json, course):
     expected_output = expected_output['courses']
     output = course.list_courses()
     assert expected_output == output
+
+def test_quiz_converter():
+    converter = api.CourseraOnDemandQuizConverter(session=None)
+    quiz_data = json.load(open('quiz.json'))['contentResponseBody']['return']
+    result = converter.convert_quiz(quiz_data)
+    # from ipdb import set_trace; set_trace(context=20)
+    print('RESULT', result)
+    with open('quiz.html', 'w') as file:
+        file.write(result)

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -1,6 +1,7 @@
 """
 Test APIs.
 """
+from os.path import expanduser
 import json
 
 import pytest
@@ -286,3 +287,34 @@ def test_quiz_converter_all():
         # print('RESULT', result)
         with open('quiz_html/' + filename + '.html', 'w') as f:
             f.write(result)
+
+def create_session():
+    from coursera.coursera_dl import get_session
+    from coursera.credentials import get_credentials
+    from coursera.cookies import login
+
+    session = get_session()
+    username, password = get_credentials(netrc=expanduser('~/.netrc'))
+    login(session, username, password)
+    return session
+
+def test_asset_retriever():
+    asset_ids = ['bWTK9sYwEeW7AxLLCrgDQQ',
+                 'bXCx18YwEeWicwr5JH8fgw',
+                 'bX9X18YwEeW7AxLLCrgDQQ',
+                 'bYHvf8YwEeWFNA5XwZEiOw',
+                 'tZmigMYxEeWFNA5XwZEiOw']
+    asset_ids = asset_ids[0:5]
+
+    more = ['VceKeChKEeaOMw70NkE3iw',
+            'VcmGXShKEea4ehL5RXz3EQ']
+
+    print('session')
+    session = create_session()
+    retriever = api.AssetRetrievier(session)
+    #assets = retriever.get(asset_ids)
+    assets = retriever(more)
+
+    print(assets)
+    from ipdb import set_trace; set_trace()
+    print(assets)

--- a/coursera/test/test_api.py
+++ b/coursera/test/test_api.py
@@ -132,10 +132,41 @@ def test_list_courses(get_page_json, course):
     assert expected_output == output
 
 def test_quiz_converter():
-    converter = api.CourseraOnDemandQuizConverter(session=None)
+    quiz_to_markup = api.QuizExamToMarkupConverter(session=None)
+    markup_to_html = api.MarkupToHTMLConverter(session=session)
+
     quiz_data = json.load(open('quiz.json'))['contentResponseBody']['return']
-    result = converter.convert_quiz(quiz_data)
+    result = markup_to_html(quiz_to_markup(quiz_data))
     # from ipdb import set_trace; set_trace(context=20)
     print('RESULT', result)
     with open('quiz.html', 'w') as file:
         file.write(result)
+
+def test_quiz_converter_all():
+    import os
+
+    from coursera.coursera_dl import get_session
+    from coursera.cookies import login
+    session = None
+    session = get_session()
+
+    quiz_to_markup = api.QuizExamToMarkupConverter(session=session)
+    markup_to_html = api.MarkupToHTMLConverter(session=session)
+
+    path = 'quiz_json'
+    for filename in os.listdir(path):
+    # for filename in ['all_question_types.json']:
+        # if 'YV0W4' not in filename:
+        #     continue
+        # if 'QVHj1' not in filename:
+        #     continue
+
+        #quiz_data = json.load(open('quiz.json'))['contentResponseBody']['return']
+        current = os.path.join(path, filename)
+        print(current)
+        quiz_data = json.load(open(current))
+        result = markup_to_html(quiz_to_markup(quiz_data))
+        # from ipdb import set_trace; set_trace(context=20)
+        # print('RESULT', result)
+        with open('quiz_html/' + filename + '.html', 'w') as f:
+            f.write(result)

--- a/coursera/test/test_parsing.py
+++ b/coursera/test/test_parsing.py
@@ -125,7 +125,7 @@ def test_parse(get_old_style_video, filename, num_sections, num_lectures,
         assert sum(r for f, r in resources if f == "mp4") == num_videos
 
 
-@patch('coursera.api.get_page_json')
+@patch('coursera.api.get_page')
 def test_get_on_demand_supplement_url_accumulates_assets(mocked):
     input = open(
         os.path.join(os.path.dirname(__file__),

--- a/coursera/test/test_parsing.py
+++ b/coursera/test/test_parsing.py
@@ -134,7 +134,8 @@ def test_get_on_demand_supplement_url_accumulates_assets(mocked):
         os.path.join(os.path.dirname(__file__),
                      "fixtures", "json", "supplement-multiple-assets-output.json")))
     mocked.return_value = json.loads(input)
-    course = api.CourseraOnDemand(session=None, course_id='0')
+    course = api.CourseraOnDemand(
+        session=None, course_id='0', course_name='test_course')
     output = course.extract_links_from_supplement('element_id')
 
     # Make sure that SOME html content has been extracted, but remove

--- a/coursera/test/test_utils.py
+++ b/coursera/test/test_utils.py
@@ -199,7 +199,8 @@ def get_mock_session(page_text):
     page_obj.text = page_text
     page_obj.raise_for_status = Mock()
     session = requests.Session()
-    session.get = Mock(return_value=page_obj)
+    session.send = Mock(return_value=page_obj)
+    session.prepare_request = Mock(return_value=None)
     return page_obj, session
 
 
@@ -208,7 +209,7 @@ def test_get_page():
 
     p = coursera_dl.get_page(session, 'http://www.not.here')
 
-    session.get.assert_called_once_with('http://www.not.here')
+    session.send.assert_called_once_with(None)
     page_obj.raise_for_status.assert_called_once_with()
     assert p == '<page/>'
 
@@ -238,7 +239,8 @@ def test_extract_supplement_links(input, output):
     page_text = slurp_fixture(input)
     expected_output = json.loads(slurp_fixture(output))
 
-    course = api.CourseraOnDemand(session=None, course_id='0')
+    course = api.CourseraOnDemand(
+        session=None, course_id='0', course_name='test_course')
     output = course._extract_links_from_text(page_text)
     # This is the easiest way to convert nested tuples to lists
     output = json.loads(json.dumps(output))

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -81,7 +81,7 @@ HTML_ESCAPE_TABLE = {
     "'": "&apos;"
 }
 
-HTML_UNESCAPE_TABLE = {v:k for k, v in HTML_ESCAPE_TABLE.items()}
+HTML_UNESCAPE_TABLE = dict((v, k) for k, v in HTML_ESCAPE_TABLE.items())
 
 
 def unescape_html(s):

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -16,6 +16,7 @@ import datetime
 
 
 from bs4 import BeautifulSoup as BeautifulSoup_
+from xml.sax.saxutils import escape, unescape
 
 import six
 from six import iteritems
@@ -71,6 +72,23 @@ def random_string(length):
     valid_chars = string_ascii_letters + string_digits
 
     return ''.join(random.choice(valid_chars) for i in range(length))
+
+
+# Taken from: https://wiki.python.org/moin/EscapingHtml
+# escape() and unescape() takes care of &, < and >.
+HTML_ESCAPE_TABLE = {
+    '"': "&quot;",
+    "'": "&apos;"
+}
+
+HTML_UNESCAPE_TABLE = {v:k for k, v in HTML_ESCAPE_TABLE.items()}
+
+
+def unescape_html(s):
+    h = html_parser.HTMLParser()
+    s = h.unescape(s)
+    s = unquote_plus(s)
+    return unescape(s, HTML_UNESCAPE_TABLE)
 
 
 def clean_filename(s, minimal_change=False):

--- a/coursera/workflow.py
+++ b/coursera/workflow.py
@@ -141,7 +141,7 @@ class CourseraDownloader(CourseDownloader):
         self._ignored_formats = ignored_formats
         self._disable_url_skipping = disable_url_skipping
 
-        self.skipped_urls = [] if disable_url_skipping else None
+        self.skipped_urls = None if disable_url_skipping else []
         self.failed_urls = []
 
     def download_modules(self, modules):


### PR DESCRIPTION
This pull request adds support for quiz/exam download. Quiz/exam content
is similar to instructions content but has its quirks. Similar to instructions,
quizzes and exams are saved into *-quiz.html or *-exam.html files. Quiz/exam
content is processed in the same way as instructions': markdown is converted
into HTML, images are downloaded and embedded, MathJAX is injected.

To enable quiz/exam download, use `--download-quizzes`.

TODO:
- [x] Add option `--download-quizzes`
- [x] Add tests for QuizExamToMarkupConverter
- [x] Add tests for MarkupToHTMLConverter
- [x] Reorganize quiz/exam extraction methods
- [x] Reorganize network.get\*page\* methods
- [x] Fix old tests
- [x] Support audio files download in quizzes (see https://www.coursera.org/learn/learn-korean/exam/dJ3ei/graded-quiz-1)
- [x] Support question types regex and mathExpression in quizzes (see https://www.coursera.org/learn/algorithmic-thinking-2/exam/JTiSG/homework-4)

fix #490
related #546