### PR TITLE
Make class_names arg optional for certain flags

### DIFF
--- a/coursera/commandline.py
+++ b/coursera/commandline.py
@@ -14,6 +14,20 @@ from .credentials import get_credentials, CredentialsError, keyring
 from .utils import decode_input
 
 
+def class_name_arg_required(args):
+    """
+    Evaluates whether class_name arg is required.
+
+    @param args: Command-line arguments.
+    @type args: namedtuple
+    """
+    no_class_name_flags = ['list_courses', 'version']
+    return not any(
+        getattr(args, flag)
+        for flag in no_class_name_flags
+    )
+
+
 def parse_args(args=None):
     """
     Parse the arguments/options passed to the program on the command line.
@@ -27,7 +41,7 @@ def parse_args(args=None):
 
     group_basic.add_argument('class_names',
                              action='store',
-                             nargs='+',
+                             nargs='*',
                              help='name(s) of the class(es) (e.g. "ml-005")')
 
     group_basic.add_argument('-u',
@@ -334,6 +348,11 @@ def parse_args(args=None):
     else:
         logging.basicConfig(level=logging.INFO,
                             format='%(message)s')
+
+    if class_name_arg_required(args) and not args.class_names:
+        parser.print_usage()
+        logging.error('You must supply at least one class name')
+        sys.exit(1)
 
     # show version?
     if args.version:

--- a/coursera/test/test_commandline.py
+++ b/coursera/test/test_commandline.py
@@ -1,0 +1,23 @@
+"""
+Test command line module.
+"""
+
+from coursera import commandline
+from coursera.test import test_workflow
+
+
+def test_class_name_arg_required():
+    args = {'list_courses': False, 'version': False}
+    mock_args = test_workflow.MockedCommandLineArgs(**args)
+    assert commandline.class_name_arg_required(mock_args)
+
+
+def test_class_name_arg_not_required():
+    not_required_cases = [
+        {'list_courses': True, 'version': False},
+        {'list_courses': False, 'version': True},
+        {'list_courses': True, 'version': True},
+    ]
+    for args in not_required_cases:
+        mock_args = test_workflow.MockedCommandLineArgs(**args)
+        assert not commandline.class_name_arg_required(mock_args)


### PR DESCRIPTION
## Proposed changes

The `class_names` argument shouldn't be required for certain flags (e.g.
`--version` or `--list-courses`).  This makes it optional while also
taking these flags into account to display an appropriate error message
when they aren't being used.

Fixes #562

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [X] I have checked that the unit tests pass locally with my changes
- [X] I have checked the style of the new code (lint/pep).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers
@balta2ar 

