### PR TITLE
Fix command typo in alternative Unix installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ following steps (create/adapt first the directory
     cd my-coursera
     source bin/activate
     git clone https://github.com/coursera-dl/coursera-dl
-    cd coursera
+    cd coursera-dl
     pip install -r requirements.txt
     ./coursera-dl ...
 
@@ -175,7 +175,7 @@ To further download new videos from your classes, simply perform:
 
     cd /directory/where/I/want/my/courses/my-coursera
     source bin/activate
-    cd coursera
+    cd coursera-dl
     ./coursera-dl ...
 
 We are working on streamlining this whole process so that it is as simple as


### PR DESCRIPTION
## Proposed changes

The section on [Alternative installation method for Unix systems](/README.md) has a command that tries to `cd coursera` when the given command to clone the repository `git clone https://github.com/coursera-dl/coursera-dl` creates a folder named `coursera-dl`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
