### PR TITLE
Improve download subtitles. Add support to download exact  subtitle

### DIFF
--- a/coursera/filtering.py
+++ b/coursera/filtering.py
@@ -94,15 +94,16 @@ def find_resources_to_get(lecture, file_formats, resource_filter, ignored_format
         logging.info("The following file formats will be ignored: " + ",".join(ignored_formats))
 
     for fmt, resources in iteritems(lecture):
-
         fmt0 = fmt
         if '.' in fmt:
-            fmt = fmt.split('.')[1]
+            short_fmt = fmt.split('.')[1]
+        else:
+            short_fmt = None
 
-        if fmt in ignored_formats:
+        if fmt in ignored_formats or short_fmt in ignored_formats:
             continue
 
-        if fmt in file_formats or 'all' in file_formats:
+        if fmt in file_formats or short_fmt in file_formats or 'all' in file_formats:
             for r in resources:
                 if resource_filter and r[1] and not re.search(resource_filter, r[1]):
                     logging.debug('Skipping b/c of rf: %s %s',

--- a/coursera/filtering.py
+++ b/coursera/filtering.py
@@ -95,15 +95,15 @@ def find_resources_to_get(lecture, file_formats, resource_filter, ignored_format
 
     for fmt, resources in iteritems(lecture):
         fmt0 = fmt
+
+        short_fmt = None
         if '.' in fmt:
             short_fmt = fmt.split('.')[1]
-        else:
-            short_fmt = None
 
-        if fmt in ignored_formats or short_fmt in ignored_formats:
+        if fmt in ignored_formats or (short_fmt != None and short_fmt in ignored_formats) :
             continue
 
-        if fmt in file_formats or short_fmt in file_formats or 'all' in file_formats:
+        if fmt in file_formats or (short_fmt != None and short_fmt in file_formats) or 'all' in file_formats:
             for r in resources:
                 if resource_filter and r[1] and not re.search(resource_filter, r[1]):
                     logging.debug('Skipping b/c of rf: %s %s',


### PR DESCRIPTION
before:
Use the following command
coursera-dl --wget -u user -p pass --resource_filter -f "en.txt en.srt" --resume algorithms-part1
can not download the en.txt and en.srt file.

You can download only pdf file  using -f "pdf" or only txt file using -f "txt".
but you can not only download en.txt file or en.srt file using -f "en.txt" or -f "en.srt"
someone only need a certain language subtitle.

After.
you can download the "en.txt en.srt" extension file using -f "en.txt en.srt"
you can download the "txt" extension file using -f "txt" too.
