### PR TITLE
Fixes repository misclassifying

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/* linguist-vendored
+coursera/test/* linguist-vendored


### PR DESCRIPTION
## Proposed changes
Coursera-dl is miss-classified as a HTML language repository in GitHub since its test folder contained a lots of HTML files. Ignoring the test folder will make the repository to be classified as python language.

Repo is listed as trending repo in HTML: https://github.com/trending/html

### References:
https://github.com/coursera-dl/coursera-dl/search?l=HTML

### Fix
Used Manual overriding to fix the miss-classification:
https://github.com/github/linguist#overrides