### PR TITLE
coursera-dl: Use a Python 3 shebang.

### DIFF
--- a/coursera-dl
+++ b/coursera-dl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from coursera import coursera_dl


### PR DESCRIPTION
This makes it more convenient for when you have your modules installed from
your Linux distribution or so.

As it only affects those that are working with a cloned git tree, it is
supposed to be the case the they know what they are doing and shouldn't
affect the vast majority of the users (the wrapper created by setup.py is a
completely different one, when users install via pip etc.).

Signed-off-by: Rogério Brito <rbrito@ime.usp.br>

/cc @balta2ar @iemejia