### PR TITLE
improve and use clean_filename

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -490,6 +490,8 @@ class CourseraOnDemand(object):
                 filename, extension = os.path.splitext(clean_url(tmpUrl))
 
                 head, tail = os.path.split(content['path'])
+                head = '/'.join([clean_filename(dir, minimal_change=True) for dir in head.split('/')])
+                tail = clean_filename(tail, minimal_change=True)
 
                 if os.path.isdir(self._course_name + "/notebook/" + head + "/") == False:
                     logging.info('Creating [{}] directories...'.format(head))

--- a/coursera/test/test_utils.py
+++ b/coursera/test/test_utils.py
@@ -34,7 +34,7 @@ from coursera.utils import total_seconds, is_course_complete
         ('Week 3: Data and Abstraction', 'Week_3-_Data_and_Abstraction'),
         ('  (Week 1) BRANDING:  Marketing Strategy and Brand Positioning',
          'Week_1_BRANDING-__Marketing_Strategy_and_Brand_Positioning'),
-        ('test &amp; &quot; adfas', 'test___adfas'),
+        ('test &amp; &quot; adfas', 'test__-_adfas'),  # `"` were changed first to `-`
         ('&nbsp;', ''),
         ('☂℮﹩т ω☤☂ℌ Ṳᾔ☤ḉ◎ⅾε', '__')
     ]
@@ -54,7 +54,7 @@ def test_clean_filename(unclean, clean):
          'Week 3- Data and Abstraction'),
         ('  (Week 1) BRANDING:  Marketing Strategy and Brand Positioning',
          '  (Week 1) BRANDING-  Marketing Strategy and Brand Positioning'),
-        ('test &amp; &quot; adfas', 'test & " adfas'),
+        ('test &amp; &quot; adfas', 'test & - adfas'),  # `"` are forbidden on Windows
         ('&nbsp;', u'\xa0'),
         ('☂℮﹩т ω☤☂ℌ Ṳᾔ☤ḉ◎ⅾε', '☂℮﹩т ω☤☂ℌ Ṳᾔ☤ḉ◎ⅾε')
     ]

--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -106,12 +106,23 @@ def clean_filename(s, minimal_change=False):
     s = unquote_plus(s)
 
     # Strip forbidden characters
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
     s = (
         s.replace(':', '-')
         .replace('/', '-')
+        .replace('<', '-')
+        .replace('>', '-')
+        .replace('"', '-')
+        .replace('\\', '-')
+        .replace('|', '-')
+        .replace('?', '-')
+        .replace('*', '-')
         .replace('\x00', '-')
-        .replace('\n', '')
+        .replace('\n', ' ')
     )
+
+    # Remove trailing dots and spaces; forbidden on Windows
+    s = s.rstrip(' .')
 
     if minimal_change:
         return s


### PR DESCRIPTION
## Context

Windows users encounter an error when a filename contains a colon (#648).

`clean_filename` which should clean paths before creation *does* handle the colon. The problem is, it's never called!

It seems that the problem lies near [this line](https://github.com/coursera-dl/coursera-dl/blob/2b9e16cc3a7b25763004d82d3a295ece69a86fe7/coursera/api.py#L492).

## Proposed changes

1. Clean file and folder names in the mentioned line. (Just in `_get_notebook_folder` now; I don't know where else it's needed.)

2. Improve `clean_filename` to handle more forbidden characters in Windows.

3. Modify the tests a little, because `"` is forbidden on Windows, and it wasn't handled before.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected))

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes **(after a little modification)**
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works **(tested it on the problematic course itself, and it works)**
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I split `head` using `split('/')` not `os.path.split()` because it's seems to me that it comes from a web page, so the separator will always be `/`, so using the native path splitting function is not the most portable way to do it.

`clean_filename` didn't handle many forbidden characters by Windows. It didn't remove trailing spaces and dots if `minimal_change` is set to `True`, which is a problem to Windows users. I added those. It still needs some work, like how to handle [forbidden names](http://sasheldon.com/blog/2017/05/07/how-i-broke-cargo-for-windows/) like `NUL` and `CON` (alone, or followed by an extension).

I also made the newline change to a space (which is changed to `_` if needed).