### PR TITLE
setup.py: Match file.open encoding with the source code encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def read_file(filename, alt=None):
     lines = None
 
     try:
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
             lines = f.read()
     except IOError:
         lines = [] if alt is None else alt


### PR DESCRIPTION
Hit encoding errors on Windows after 0.11, easiest solution is to match encodings.

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes
Honestly, not sure why this happens, but this should future proof it. Change setup.py to open files (and quotes inside setup.py) with utf-8, same as the source encoding.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, please explain why you chose
the solution you did and what alternatives you considered, etc.

### Reviewers
If you know the person who can review your code please add a @mention.
