### PR TITLE
Fix proxy setting from environment variable

### DIFF
--- a/coursera/network.py
+++ b/coursera/network.py
@@ -34,14 +34,11 @@ def get_reply(session, url, post=False, data=None, headers=None):
     """
 
     request_headers = {} if headers is None else headers
-
-    request = requests.Request('POST' if post else 'GET',
-                               url,
-                               data=data,
-                               headers=request_headers)
-    prepared_request = session.prepare_request(request)
-
-    reply = session.send(prepared_request)
+    
+    reply = session.request('POST' if post else 'GET',
+                            url,
+                            data=data,
+                            headers=request_headers)
 
     try:
         reply.raise_for_status()


### PR DESCRIPTION
## Proposed changes

Use `session.request` instead of creating a `Request` object manually and calling `session.prepare_request` because there are extra steps that is done in `session.request` i.e. calling [`merge_environment_settings`](https://github.com/requests/requests/blob/master/requests/sessions.py#L502) which is responsible for setting the proxy and other settings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
