### PR TITLE
Getting enviroment variables before make a session send request.

### DIFF
--- a/coursera/network.py
+++ b/coursera/network.py
@@ -45,7 +45,9 @@ def get_reply(session, url, post=False, data=None, headers=None, quiet=False):
                                headers=request_headers)
     prepared_request = session.prepare_request(request)
 
-    reply = session.send(prepared_request)
+    settings = session.merge_environment_settings(request.url, {}, False, False, None)
+
+    reply = session.send(prepared_request, **settings)
 
     try:
         reply.raise_for_status()


### PR DESCRIPTION
## Proposed change

In order to download courses behind a proxy server, referenced in the issues #205, #594 and #613, it's necessary get the proxy environment variables before do session.send() in file network.py. Due to some different behaviors in request module these variables was no used to make the request. Therefore, in order to get environment settings was added the line:

`settings = session.merge_environment_settings(request.url, {}, False, False, None)`

Then the request was made with these settings using:

`reply = session.send(prepared_request, **settings)`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

