### PR TITLE
added ca param on command line - good solution for #702

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ class names, as well as any additional parameters:
 
     General:                     coursera-dl -u <user> -p <pass> modelthinking-004
 
+    With CAUTH parameter:	 coursera-dl -ca 'some-ca-value-from-browser' modelthinking-004
+
 If you don't want to type your password in command line as plain text, you can use the script without `-p` option. In this case you will be prompted for password  once the script is run.
 
     Without -p field:            coursera-dl -u <user> modelthinking-004

--- a/coursera/commandline.py
+++ b/coursera/commandline.py
@@ -342,6 +342,14 @@ def parse_args(args=None):
         'Advanced authentication options')
 
     group_adv_auth.add_argument(
+        '-ca',
+        '--cauth',
+        dest='cookies_cauth',
+        action='store',
+        default=None,
+        help='cauth cookie value from browser')
+
+    group_adv_auth.add_argument(
         '-c',
         '--cookies_file',
         dest='cookies_file',
@@ -492,7 +500,7 @@ def parse_args(args=None):
         logging.error('Cookies file not found: %s', args.cookies_file)
         sys.exit(1)
 
-    if not args.cookies_file:
+    if not args.cookies_file and not args.cookies_cauth:
         try:
             args.username, args.password = get_credentials(
                 username=args.username, password=args.password,

--- a/coursera/coursera_dl.py
+++ b/coursera/coursera_dl.py
@@ -233,7 +233,10 @@ def main():
         return
 
     session = get_session()
-    login(session, args.username, args.password)
+    if args.cookies_cauth:
+        session.cookies.set('CAUTH', args.cookies_cauth)
+    else:
+        login(session, args.username, args.password)
     if args.specialization:
         args.class_names = expand_specializations(session, args.class_names)
 


### PR DESCRIPTION
## Proposed changes

This allows to specify a 'ca' parameter at command line instaed of the crednetials or a cookie file.
It works great with options like `--download-quizzes`  which other workarounds for issue [#702](https://github.com/coursera-dl/coursera-dl/issues/702) are not abkle to do as well. 

This is much cleaner implementation.
## Types of changes

1. login coursera from your browser
2. copy CAUTH value from your cookies list. For chrome on the tab with coursera open developer tools -> application -> cookies -> https://www.coursera.org -> CAUTH
3. `coursera-dl -ca 'cauth-value-copied-from-browser' modelthinking-004`

### Reviewers
I @jethar have reveiwed the changes and seen that it works properly.

