### PR TITLE
Fix#778 - HTMLParser.unescape was removed from Python since version 3.9.0a1 

### DIFF
--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -14,7 +14,7 @@ import random
 import string
 import logging
 import datetime
-
+import html
 
 from bs4 import BeautifulSoup as BeautifulSoup_
 from xml.sax.saxutils import escape, unescape
@@ -114,8 +114,7 @@ def clean_filename(s, minimal_change=False):
     """
 
     # First, deal with URL encoded strings
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html.unescape(s)
     s = unquote_plus(s)
 
     # Strip forbidden characters


### PR DESCRIPTION
…ause deprecated

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

HTMLParser.unescape was deprecated and removed from Python since version 3.9.0a1 
So i just use html.unescape() instead of the original HTMLParser.unescape()

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x ] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, please explain why you chose
the solution you did and what alternatives you considered, etc.

### Reviewers
If you know the person who can review your code please add a @mention.
