### PR TITLE
Fix some SyntaxWarnings

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -945,7 +945,7 @@ class CourseraOnDemand(object):
 
         def _add_asset(name, url, destination):
             filename, extension = os.path.splitext(clean_url(name))
-            if extension is '':
+            if extension == '':
                 return
 
             extension = clean_filename(
@@ -1590,7 +1590,7 @@ class CourseraOnDemand(object):
             filename, extension = os.path.splitext(clean_url(link))
             # Some courses put links to sites in supplement section, e.g.:
             # http://pandas.pydata.org/
-            if extension is '':
+            if extension == '':
                 continue
 
             # Make lowercase and cut the leading/trailing dot


### PR DESCRIPTION
* On Python 3.8.5 during normal execution the following is logged:
  SyntaxWarning: "is" with a literal. Did you mean "=="?

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

Eliminate some annoying SyntaxWarning messages.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This should not change the functionality.

### Reviewers
@felker @balta2ar 
