### PR TITLE
Fix AttributeError: 'HTMLParser' object has no attribute 'unescape'

### DIFF
--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -21,7 +21,11 @@ from xml.sax.saxutils import escape, unescape
 
 import six
 from six import iteritems
-from six.moves import html_parser
+if six.PY34:
+    import html
+else:
+    from six.moves import html_parser
+    html = html_parser.HTMLParser()
 from six.moves.urllib.parse import ParseResult
 from six.moves.urllib_parse import unquote_plus
 
@@ -98,8 +102,7 @@ HTML_UNESCAPE_TABLE = dict((v, k) for k, v in HTML_ESCAPE_TABLE.items())
 
 
 def unescape_html(s):
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html.unescape(s)
     s = unquote_plus(s)
     return unescape(s, HTML_UNESCAPE_TABLE)
 
@@ -114,8 +117,7 @@ def clean_filename(s, minimal_change=False):
     """
 
     # First, deal with URL encoded strings
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html.unescape(s)
     s = unquote_plus(s)
 
     # Strip forbidden characters


### PR DESCRIPTION
## Proposed changes

Execution with Python 3.9 generated the following error:
> [...]
> File "/usr/local/lib/python3.9/site-packages/coursera/utils.py", line 118, in clean_filename
>    s = h.unescape(s)
> AttributeError: 'HTMLParser' object has no attribute 'unescape'

This it due to the following:
> The unescape() method in the html.parser.HTMLParser class has been removed (it was deprecated since Python 3.4). html.unescape() should be used for converting character references to the corresponding unicode characters.
(https://docs.python.org/3/whatsnew/3.9.html)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers
