### PR TITLE
Upgrade six and attrs dependencies.

### DIFF
--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -98,8 +98,7 @@ HTML_UNESCAPE_TABLE = dict((v, k) for k, v in HTML_ESCAPE_TABLE.items())
 
 
 def unescape_html(s):
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html_parser.unescape(s)
     s = unquote_plus(s)
     return unescape(s, HTML_UNESCAPE_TABLE)
 
@@ -114,8 +113,7 @@ def clean_filename(s, minimal_change=False):
     """
 
     # First, deal with URL encoded strings
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html_parser.unescape(s)
     s = unquote_plus(s)
 
     # Strip forbidden characters

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mock>=1.0.1
 coverage>=3.7
 keyrings.alt
 tox
+attrs>=21.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4.1.3
 requests>=2.10.0
-six>=1.5.0
+six>=1.16.0
 urllib3>=1.23
 pyasn1>=0.1.7
 keyring>=4.0


### PR DESCRIPTION
## Proposed changes

This issue is addressed
https://github.com/coursera-dl/coursera-dl/issues/817

With this fix, the bug is fixed where the `unescape` function can be directly referenced from `six.moves.html_parser`

`attrs` and `six` package dependencies are upgraded.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

