### PR TITLE
Allow Aria2 downloader to use absolute paths.

### DIFF
--- a/coursera/downloaders.py
+++ b/coursera/downloaders.py
@@ -186,8 +186,9 @@ class Aria2Downloader(ExternalDownloader):
     def _add_cookies(self, command, cookie_values):
         command.extend(['--header', "Cookie: " + cookie_values])
 
-    def _create_command(self, url, filename):
-        return [self.bin, url, '-o', filename,
+    def _create_command(self, url, filepath):
+        filedir, filename = os.path.split(filepath)
+        return [self.bin, url, '-o', filename, '--dir', filedir or '.',
                 '--check-certificate=false', '--log-level=notice',
                 '--max-connection-per-server=4', '--min-split-size=1M']
 

--- a/coursera/test/test_downloaders.py
+++ b/coursera/test/test_downloaders.py
@@ -153,10 +153,22 @@ def test_aria2():
     s = _ext_get_session()
 
     d = downloaders.Aria2Downloader(s)
-    command = d._create_command('download_url', 'save_to')
+    absolute_filepath = '/absolute/path/to/save_to'
+    command = d._create_command('download_url', absolute_filepath)
     assert command[0] == 'aria2c'
     assert 'download_url' in command
+    assert '/absolute/path/to' in command
     assert 'save_to' in command
+    assert absolute_filepath not in command, \
+        'Absolute filepath should be split'
+
+    d = downloaders.Aria2Downloader(s)
+    relative_filepath = 'save_to'
+    command = d._create_command('download_url', relative_filepath)
+    assert command[0] == 'aria2c'
+    assert 'download_url' in command
+    assert relative_filepath in command
+    assert '.' in command, 'Relative filepath should use --dir .'
 
     d._prepare_cookies(command, 'http://www.coursera.org')
     assert any("Cookie: " in e for e in command)


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

This should fix #275.

The downloader for aria2 has a bug which prevents it from supporting absolute paths.

From aria2c manpage (v1.35.0):
```
-o, --out=<FILE>
              The file name of the downloaded file.  It is always relative  to
              the    directory    given    in    --dir   option.    When   the
              --force-sequential option is used, this option is ignored.
```
Thus both `--dir` and `--out` should be specified together for absolute paths, but instead `Aria2Downloader` in `downloaders.py` specifies the full path in `--out`, causing the working directory to be appended to all paths:
```python
def _create_command(self, url, filename):
        return [self.bin, url, '-o', filename,
                '--check-certificate=false', '--log-level=notice',
                '--max-connection-per-server=4', '--min-split-size=1M']
``` 
For example, if you run `coursera-dl` in working directory `/home/user1/` and specify `--path /home/user1/downloads`, aria2 will download to a directory `/home/user1//home/user1/downloads`. This is what @FinalTheory reported, and is still the behavior as of the latest `coursera-dl` on PyPi (0.11.5).

This change is a simple fix, though I suspect it would be easier and more robust to avoid these sorts of issues by changing the `_create_command` interface to pass in filedir and filename separately.

## Testing
Added Aria2 downloader unit tests for relative and absolute paths.

I also tested the script myself using absolute and relative paths on real courses, both cases worked.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers
@rbrito 
