### PR TITLE
update OnDemandCourseMaterials api to version 2

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -284,7 +284,7 @@ class MarkupToHTMLConverter(object):
                 audio.insert_after(controls_tag)
 
 
-class OnDemandCourseMaterialItemsV1(object):
+class OnDemandCourseMaterialItemsV2(object):
     """
     Helper class that allows accessing lecture JSONs by lesson IDs.
     """
@@ -315,11 +315,11 @@ class OnDemandCourseMaterialItemsV1(object):
         @rtype: OnDemandCourseMaterialItems
         """
 
-        dom = get_page(session, OPENCOURSE_ONDEMAND_COURSE_MATERIALS,
+        dom = get_page(session, OPENCOURSE_ONDEMAND_COURSE_MATERIALS_V2,
                        json=True,
                        class_name=course_name)
-        return OnDemandCourseMaterialItemsV1(
-            dom['linked']['onDemandCourseMaterialItems.v1'])
+        return OnDemandCourseMaterialItemsV2(
+            dom['linked']['onDemandCourseMaterialItems.v2'])
 
     def get(self, lesson_id):
         """

--- a/coursera/extractors.py
+++ b/coursera/extractors.py
@@ -9,7 +9,7 @@ import abc
 import json
 import logging
 
-from .api import (CourseraOnDemand, OnDemandCourseMaterialItemsV1,
+from .api import (CourseraOnDemand, OnDemandCourseMaterialItemsV2,
                   ModulesV1, LessonsV1, ItemsV2)
 from .define import OPENCOURSE_ONDEMAND_COURSE_MATERIALS_V2
 from .network import get_page
@@ -102,7 +102,7 @@ class CourseraExtractor(PlatformExtractor):
             unrestricted_filenames=unrestricted_filenames,
             mathjax_cdn_url=mathjax_cdn_url)
         course.obtain_user_id()
-        ondemand_material_items = OnDemandCourseMaterialItemsV1.create(
+        ondemand_material_items = OnDemandCourseMaterialItemsV2.create(
             session=self._session, course_name=course_name)
 
         if is_debug_run():


### PR DESCRIPTION
change class name to OnDemandCourseMaterialItemsV2 and add update lines 318 and 322 of api.py file

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

These commits aim to fix the problem mentioned in [issue 834](https://github.com/coursera-dl/coursera-dl/issues/834)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
