### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.1.3
 requests>=2.10.0
 six>=1.5.0
-urllib3>=1.23
+urllib3>=1.26.5
 pyasn1>=0.1.7
 keyring>=4.0
 configargparse>=0.12.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.23
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.23 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS