### PR TITLE
Updated OPENCOURSE_ONDEMAND_COURSE_MATERIALS to v2

### DIFF
--- a/coursera/api.py
+++ b/coursera/api.py
@@ -315,11 +315,11 @@ class OnDemandCourseMaterialItemsV1(object):
         @rtype: OnDemandCourseMaterialItems
         """
 
-        dom = get_page(session, OPENCOURSE_ONDEMAND_COURSE_MATERIALS,
+        dom = get_page(session, OPENCOURSE_ONDEMAND_COURSE_MATERIALS_V2,
                        json=True,
                        class_name=course_name)
         return OnDemandCourseMaterialItemsV1(
-            dom['linked']['onDemandCourseMaterialItems.v1'])
+            dom['linked']['onDemandCourseMaterialItems.v2'])
 
     def get(self, lesson_id):
         """


### PR DESCRIPTION
Old v1 endpoint was deprecated so updated api.py to the new v2 endpoint based on [this](https://github.com/coursera-dl/coursera-dl/issues/834) thread.